### PR TITLE
Fix issues when initializing trusted SSL socket factory

### DIFF
--- a/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.extension.rest.api/pom.xml
+++ b/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.extension.rest.api/pom.xml
@@ -58,6 +58,12 @@
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.core</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.wso2.carbon</groupId>
+                    <artifactId>org.wso2.carbon.base</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.json.wso2</groupId>
@@ -81,6 +87,10 @@
         <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.user.api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.base</artifactId>
         </dependency>
     </dependencies>
 
@@ -106,6 +116,7 @@
                         <Import-Package>
                             org.osgi.framework.*;version="${imp.package.version.osgi.framework}",
                             org.osgi.service.*;version="${imp.package.version.osgi.service}",
+                            org.wso2.carbon.base;version="[1.0,2)",
                             org.wso2.carbon.core;version="4.6",
                             org.wso2.carbon.core.util;version="4.6",
                             org.apache.commons.ssl,


### PR DESCRIPTION
## Purpose
> Starting with Java 8u31, SSLv3 was disabled by default in Java. Later versions, including Java 11 and beyond, completely removed support for SSLv3. (security vulnerability - AKA POODLE)

## Goals
> Fixes for https://roadmap.entgra.net/issues/12380

## Approach
> The followings were carried out,
> * Removed deprecated okhttp ssl socket factory creation method and updated it to newer.
> * Fix OSGi issues when package activating
> * Update transport layer security to TLSv1.2 standards (removed SSLv3)

## Test environment
> cloud staging node (https://mgt.cloudstaging.entgra.net)