### PR TITLE
Update access modifier for removeDeviceFromCache methods

### DIFF
--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/service/DeviceManagementProviderService.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/service/DeviceManagementProviderService.java
@@ -20,6 +20,7 @@ package io.entgra.device.mgt.core.device.mgt.core.service;
 
 import io.entgra.device.mgt.core.device.mgt.common.app.mgt.Application;
 import io.entgra.device.mgt.core.device.mgt.common.exceptions.ConflictException;
+import io.entgra.device.mgt.core.device.mgt.core.cache.DeviceCacheKey;
 import io.entgra.device.mgt.core.device.mgt.core.dto.DeviceDetailsDTO;
 import io.entgra.device.mgt.core.device.mgt.core.dto.OperationDTO;
 import io.entgra.device.mgt.core.device.mgt.core.dto.OwnerWithDeviceDTO;
@@ -778,6 +779,10 @@ public interface DeviceManagementProviderService {
     boolean isDeviceMonitoringEnabled(String deviceType);
 
     PolicyMonitoringManager getPolicyMonitoringManager(String deviceType);
+
+    void removeDeviceFromCache(DeviceIdentifier deviceIdentifier);
+
+    void removeDevicesFromCache(List<DeviceCacheKey> deviceList);
 
     /**
      * Change device status.

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
@@ -3916,7 +3916,7 @@ public class DeviceManagementProviderServiceImpl implements DeviceManagementProv
         DeviceCacheManagerImpl.getInstance().addDeviceToCache(deviceIdentifier, device, this.getTenantId());
     }
 
-    private void removeDeviceFromCache(DeviceIdentifier deviceIdentifier) {
+    public void removeDeviceFromCache(DeviceIdentifier deviceIdentifier) {
         DeviceCacheManagerImpl.getInstance().removeDeviceFromCache(deviceIdentifier, this.getTenantId());
     }
 
@@ -3928,7 +3928,7 @@ public class DeviceManagementProviderServiceImpl implements DeviceManagementProv
      * This method removes a given list of devices from the cache
      * @param deviceList list of DeviceCacheKey objects
      */
-    private void removeDevicesFromCache(List<DeviceCacheKey> deviceList) {
+    public void removeDevicesFromCache(List<DeviceCacheKey> deviceList) {
         DeviceCacheManagerImpl.getInstance().removeDevicesFromCache(deviceList);
     }
 


### PR DESCRIPTION
## Purpose
>  The removeDeviceCache method's access modifier has been changed to enable direct external use. This adjustment was made to allow other components or modules to invoke the method as required



