### PR TITLE
Send policy_revoke before device disenrollment

### DIFF
--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/DeviceManager.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/DeviceManager.java
@@ -181,4 +181,13 @@ public interface DeviceManager {
      */
     boolean requireDeviceAuthorization();
 
+    /**
+     * Method to remove a particular device from CDM.
+     *
+     * @param deviceId Fully qualified device identifier
+     * @return A boolean indicating the status of the operation.
+     * @throws DeviceManagementException If some unusual behaviour is observed while removing a device
+     */
+    boolean removeDevice(DeviceIdentifier deviceId) throws DeviceManagementException;
+
 }

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/mgt/OperationManagerImpl.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/mgt/OperationManagerImpl.java
@@ -1043,8 +1043,10 @@ public class OperationManagerImpl implements OperationManager {
         } catch (TransactionManagementException e) {
             throw new OperationManagementException("Error occurred while initiating a transaction", e);
         } catch (DeviceManagementException e) {
-            throw new OperationManagementException("Error while checking the existence of the device identifier - "
-                    + deviceId.getId() + " of the device type - " + deviceId.getType(), e);
+            String msg = "Error while checking the existence of the device identifier - "
+                    + deviceId.getId() + " of the device type - " + deviceId.getType();
+            log.error(msg, e);
+            throw new OperationManagementException(msg, e);
         } finally {
             OperationManagementDAOFactory.closeConnection();
         }

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/mgt/OperationManagerImpl.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/mgt/OperationManagerImpl.java
@@ -937,6 +937,13 @@ public class OperationManagerImpl implements OperationManager {
                         }
                     }
                 }
+                if (operation.getCode().equals("POLICY_REVOKE") && operation.getStatus().equals(Operation.Status.COMPLETED)){
+                    if (this.getDevice(deviceId).getEnrolmentInfo().getStatus().equals(EnrolmentInfo.Status.DISENROLLMENT_REQUESTED)) {
+                        DeviceManagementProviderService deviceManagementProviderService = DeviceManagementDataHolder.getInstance().
+                                getDeviceManagementProvider();
+                        deviceManagementProviderService.removeDevice(deviceId);
+                    }
+                }
             }
             if (!isOperationUpdated) {
                 log.warn("Operation " + operationId + "'s status is not updated");
@@ -1035,6 +1042,9 @@ public class OperationManagerImpl implements OperationManager {
             }
         } catch (TransactionManagementException e) {
             throw new OperationManagementException("Error occurred while initiating a transaction", e);
+        } catch (DeviceManagementException e) {
+            throw new OperationManagementException("Error while checking the existence of the device identifier - "
+                    + deviceId.getId() + " of the device type - " + deviceId.getType(), e);
         } finally {
             OperationManagementDAOFactory.closeConnection();
         }

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/service/DeviceManagementProviderService.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/service/DeviceManagementProviderService.java
@@ -674,6 +674,8 @@ public interface DeviceManagementProviderService {
 
     boolean disenrollDevice(DeviceIdentifier deviceId) throws DeviceManagementException;
 
+    boolean removeDevice(DeviceIdentifier deviceId) throws DeviceManagementException;
+
     boolean deleteDevices(List<String> deviceIdentifiers) throws DeviceManagementException, InvalidDeviceException;
 
     boolean isEnrolled(DeviceIdentifier deviceId) throws DeviceManagementException;
@@ -1025,6 +1027,14 @@ public interface DeviceManagementProviderService {
             throws DeviceManagementException;
 
     Boolean sendDeviceNameChangedNotification(Device device) throws DeviceManagementException;
+
+    /**
+     * This method creates an activity to send a policy revoke operation.
+     * @param deviceIdentifier device identifier.
+     * @return {@link Activity}
+     * @throws DeviceManagementException if any service level or DAO level error occurs.
+     */
+    Activity sendPolicyRevokeOperation(DeviceIdentifier deviceIdentifier) throws DeviceManagementException;
 
     /**
      * This method is for saving application icon info

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/test/java/io/entgra/device/mgt/core/device/mgt/core/TestDeviceManager.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/test/java/io/entgra/device/mgt/core/device/mgt/core/TestDeviceManager.java
@@ -62,6 +62,11 @@ public class TestDeviceManager implements DeviceManager {
     }
 
     @Override
+    public boolean removeDevice(DeviceIdentifier deviceId) throws DeviceManagementException {
+        return true;
+    }
+
+    @Override
     public void deleteDevices(List<String> deviceIdentifiers) throws DeviceManagementException {
     }
 

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/test/java/io/entgra/device/mgt/core/device/mgt/core/operation/OperationManagementTests.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/test/java/io/entgra/device/mgt/core/device/mgt/core/operation/OperationManagementTests.java
@@ -502,7 +502,7 @@ public class OperationManagementTests extends BaseDeviceManagementTest {
     @Test(dependsOnMethods = {"getOperationByActivityIdAndDevice", "getOperationByActivityIdAndDeviceAsNonAdmin"})
     public void getOperationForInactiveDevice() throws DeviceManagementException, OperationManagementException {
         boolean disEnrolled = DeviceManagementDataHolder.getInstance().getDeviceManagementProvider().
-                disenrollDevice(deviceIds.get(0));
+                removeDevice(deviceIds.get(0));
         Assert.assertTrue(disEnrolled);
         List operations = this.operationMgtService.getOperations(deviceIds.get(0));
         Assert.assertTrue(operations == null);

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/test/java/io/entgra/device/mgt/core/device/mgt/core/service/DeviceManagementProviderServiceTest.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/test/java/io/entgra/device/mgt/core/device/mgt/core/service/DeviceManagementProviderServiceTest.java
@@ -244,7 +244,7 @@ public class DeviceManagementProviderServiceTest extends BaseDeviceManagementTes
     public void testDisenrollment() throws DeviceManagementException {
         if (!isMock()) {
             Device device = TestDataHolder.generateDummyDeviceData(new DeviceIdentifier(DEVICE_ID, DEVICE_TYPE));
-            boolean disenrollmentStatus = deviceMgtService.disenrollDevice(new DeviceIdentifier
+            boolean disenrollmentStatus = deviceMgtService.removeDevice(new DeviceIdentifier
                     (device.getDeviceIdentifier(), device.getType()));
             log.info(disenrollmentStatus);
             Assert.assertTrue(disenrollmentStatus);
@@ -280,7 +280,7 @@ public class DeviceManagementProviderServiceTest extends BaseDeviceManagementTes
         if (!isMock()) {
             Device device = TestDataHolder.generateDummyDeviceData(new DeviceIdentifier(DEVICE_ID,
                     DEVICE_TYPE));
-            boolean result = deviceMgtService.disenrollDevice(new DeviceIdentifier(
+            boolean result = deviceMgtService.removeDevice(new DeviceIdentifier(
                     device.getDeviceIdentifier(), device.getType()));
             Assert.assertTrue(result);
         }

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.extensions/src/main/java/io/entgra/device/mgt/core/device/mgt/extensions/device/type/template/DeviceTypeManager.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.extensions/src/main/java/io/entgra/device/mgt/core/device/mgt/extensions/device/type/template/DeviceTypeManager.java
@@ -395,6 +395,12 @@ public class DeviceTypeManager implements DeviceManager {
     }
 
     @Override
+    public boolean removeDevice(DeviceIdentifier deviceId) throws DeviceManagementException {
+        //Here we don't have anything specific to do. Hence returning.
+        return true;
+    }
+
+    @Override
     public boolean isEnrolled(DeviceIdentifier deviceId) throws DeviceManagementException {
         if (deviceId == null) {
             throw new DeviceManagementException("Cannot check the enrollment status of a null device");

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.extensions/src/test/java/io/entgra/device/mgt/core/device/mgt/extensions/mock/TypeXDeviceManager.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.extensions/src/test/java/io/entgra/device/mgt/core/device/mgt/extensions/mock/TypeXDeviceManager.java
@@ -58,6 +58,11 @@ public class TypeXDeviceManager implements DeviceManager {
     }
 
     @Override
+    public boolean removeDevice(DeviceIdentifier deviceId) throws DeviceManagementException {
+        return false;
+    }
+
+    @Override
     public void deleteDevices(List<String> deviceIdentifiers) throws DeviceManagementException {
     }
 

--- a/components/policy-mgt/io.entgra.device.mgt.core.policy.mgt.core/src/test/java/io/entgra/device/mgt/core/policy/mgt/core/mock/TypeXDeviceManager.java
+++ b/components/policy-mgt/io.entgra.device.mgt.core.policy.mgt.core/src/test/java/io/entgra/device/mgt/core/policy/mgt/core/mock/TypeXDeviceManager.java
@@ -58,6 +58,11 @@ public class TypeXDeviceManager implements DeviceManager {
     }
 
     @Override
+    public boolean removeDevice(DeviceIdentifier deviceId) throws DeviceManagementException {
+        return false;
+    }
+
+    @Override
     public void deleteDevices(List<String> deviceIdentifiers) throws DeviceManagementException {
     }
 


### PR DESCRIPTION
## Purpose

- Fixes https://roadmap.entgra.net/issues/11178

## Description

- When disenrolling a device a policy_revoke operation will be added first
- Then device will go to a state called DISENROLLMENT_REQUESTED
- Once the policy_revoke is synced to the device and gets completed, device will be moved to REMOVED state

## Related PRs:
- https://github.com/entgra-proprietary/ui-components/pull/20
- https://github.com/entgra-proprietary/emm-proprietary-plugins/pull/85