### PR TITLE
Fix enterprise application sync issue with app subscription

### DIFF
--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/impl/DeviceManagementServiceImpl.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/impl/DeviceManagementServiceImpl.java
@@ -1739,7 +1739,11 @@ public class DeviceManagementServiceImpl implements DeviceManagementService {
             DeviceMgtAPIUtils.getDeviceManagementService().updateOperation(device, operation);
 
             if (MDMAppConstants.AndroidConstants.OPCODE_INSTALL_APPLICATION.equals(operation.getCode()) ||
-                    MDMAppConstants.AndroidConstants.OPCODE_UNINSTALL_APPLICATION.equals(operation.getCode())) {
+                    MDMAppConstants.AndroidConstants.OPCODE_UNINSTALL_APPLICATION.equals(operation.getCode()) ||
+                    MDMAppConstants.WindowsConstants.INSTALL_ENTERPRISE_APPLICATION.equals(operation.getCode()) ||
+                    MDMAppConstants.WindowsConstants.UNINSTALL_ENTERPRISE_APPLICATION.equals(operation.getCode()) ||
+                    MDMAppConstants.WindowsConstants.INSTALL_STORE_APPLICATION.equals(operation.getCode()) ||
+                    MDMAppConstants.WindowsConstants.UNINSTALL_STORE_APPLICATION.equals(operation.getCode())) {
                 ApplicationManager applicationManager = DeviceMgtAPIUtils.getApplicationManager();
                 applicationManager.updateSubsStatus(device.getId(), operation.getId(), operation.getStatus().toString());
             }

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/impl/DeviceManagementServiceImpl.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/impl/DeviceManagementServiceImpl.java
@@ -1733,19 +1733,28 @@ public class DeviceManagementServiceImpl implements DeviceManagementService {
                 log.error(msg);
                 return Response.status(Response.Status.BAD_REQUEST).entity(msg).build();
             }
+
             Operation operation = DeviceMgtAPIUtils.validateOperationStatusBean(operationStatusBean);
             operation.setId(operationStatusBean.getOperationId());
             operation.setCode(operationStatusBean.getOperationCode());
-            DeviceMgtAPIUtils.getDeviceManagementService().updateOperation(device, operation);
 
-            if (MDMAppConstants.AndroidConstants.OPCODE_INSTALL_APPLICATION.equals(operation.getCode()) ||
-                    MDMAppConstants.AndroidConstants.OPCODE_UNINSTALL_APPLICATION.equals(operation.getCode()) ||
-                    MDMAppConstants.WindowsConstants.INSTALL_ENTERPRISE_APPLICATION.equals(operation.getCode()) ||
-                    MDMAppConstants.WindowsConstants.UNINSTALL_ENTERPRISE_APPLICATION.equals(operation.getCode()) ||
-                    MDMAppConstants.WindowsConstants.INSTALL_STORE_APPLICATION.equals(operation.getCode()) ||
-                    MDMAppConstants.WindowsConstants.UNINSTALL_STORE_APPLICATION.equals(operation.getCode())) {
-                ApplicationManager applicationManager = DeviceMgtAPIUtils.getApplicationManager();
-                applicationManager.updateSubsStatus(device.getId(), operation.getId(), operation.getStatus().toString());
+            switch (operation.getCode()) {
+                case MDMAppConstants.AndroidConstants.OPCODE_INSTALL_APPLICATION:
+                case MDMAppConstants.AndroidConstants.OPCODE_UNINSTALL_APPLICATION:
+                case MDMAppConstants.WindowsConstants.INSTALL_ENTERPRISE_APPLICATION:
+                case MDMAppConstants.WindowsConstants.UNINSTALL_ENTERPRISE_APPLICATION:
+                case MDMAppConstants.WindowsConstants.INSTALL_STORE_APPLICATION:
+                case MDMAppConstants.WindowsConstants.UNINSTALL_STORE_APPLICATION:
+
+                    DeviceMgtAPIUtils.getDeviceManagementService().updateOperation(device, operation);
+                    ApplicationManager applicationManager = DeviceMgtAPIUtils.getApplicationManager();
+                    applicationManager.updateSubsStatus(device.getId(), operation.getId(), operation.getStatus().toString());
+                    break;
+
+                default:
+                    String msg = "Unsupported operation code: " + operation.getCode();
+                    log.error(msg);
+                    return Response.status(Response.Status.BAD_REQUEST).entity(msg).build();
             }
             return Response.status(Response.Status.OK).entity("OperationStatus updated successfully.").build();
         } catch (BadRequestException e) {

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/impl/DeviceManagementServiceImpl.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/impl/DeviceManagementServiceImpl.java
@@ -1745,12 +1745,10 @@ public class DeviceManagementServiceImpl implements DeviceManagementService {
                 case MDMAppConstants.WindowsConstants.UNINSTALL_ENTERPRISE_APPLICATION:
                 case MDMAppConstants.WindowsConstants.INSTALL_STORE_APPLICATION:
                 case MDMAppConstants.WindowsConstants.UNINSTALL_STORE_APPLICATION:
-
                     DeviceMgtAPIUtils.getDeviceManagementService().updateOperation(device, operation);
                     ApplicationManager applicationManager = DeviceMgtAPIUtils.getApplicationManager();
                     applicationManager.updateSubsStatus(device.getId(), operation.getId(), operation.getStatus().toString());
                     break;
-
                 default:
                     String msg = "Unsupported operation code: " + operation.getCode();
                     log.error(msg);

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/impl/DeviceManagementServiceImpl.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/impl/DeviceManagementServiceImpl.java
@@ -1746,8 +1746,9 @@ public class DeviceManagementServiceImpl implements DeviceManagementService {
                 case MDMAppConstants.WindowsConstants.INSTALL_STORE_APPLICATION:
                 case MDMAppConstants.WindowsConstants.UNINSTALL_STORE_APPLICATION:
                     DeviceMgtAPIUtils.getDeviceManagementService().updateOperation(device, operation);
-                    ApplicationManager applicationManager = DeviceMgtAPIUtils.getApplicationManager();
-                    applicationManager.updateSubsStatus(device.getId(), operation.getId(), operation.getStatus().toString());
+                    DeviceMgtAPIUtils.getApplicationManager().updateSubsStatus(
+                            device.getId(), operation.getId(), operation.getStatus().toString()
+                    );
                     break;
                 default:
                     String msg = "Unsupported operation code: " + operation.getCode();


### PR DESCRIPTION
Fixed an issue where Windows applications were not syncing with app subscription details. Previously, when the app installation or uninstallation operation status was updated through the device's operation logs, the app subscription status remained unchanged.
Ticket: https://roadmap.entgra.net/issues/12608