### PR TITLE
Fix json object type in ApiApplicationKey

### DIFF
--- a/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.application.extension/pom.xml
+++ b/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.application.extension/pom.xml
@@ -71,8 +71,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.json-simple.wso2</groupId>
-            <artifactId>json-simple</artifactId>
+            <groupId>org.json.wso2</groupId>
+            <artifactId>json</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -136,6 +136,7 @@
                         <Private-Package>io.entgra.device.mgt.core.apimgt.application.extension.internal</Private-Package>
                         <Import-Package>
                             com.google.gson;version="${google.gson.version}",
+                            org.json;version="[3.0,4)",
                             io.entgra.device.mgt.core.apimgt.extension.rest.api;version="${io.entgra.device.mgt.core.version.range}",
                             io.entgra.device.mgt.core.apimgt.extension.rest.api.bean.APIMConsumer;version="${io.entgra.device.mgt.core.version.range}",
                             io.entgra.device.mgt.core.apimgt.extension.rest.api.dto;version="${io.entgra.device.mgt.core.version.range}",
@@ -149,7 +150,6 @@
                             okhttp3,
                             org.apache.commons.lang;version="[2.6,3)",
                             org.apache.commons.logging;version="[1.2,2)",
-                            org.json.simple;version="[1.1,2)",
                             org.osgi.framework;version="${imp.package.version.osgi.framework}",
                             org.osgi.service.component;version="${imp.package.version.osgi.service}",
                             org.wso2.carbon.apimgt.api;version="[9.28,10)",

--- a/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.application.extension/src/main/java/io/entgra/device/mgt/core/apimgt/application/extension/bean/ApiApplicationKey.java
+++ b/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.application.extension/src/main/java/io/entgra/device/mgt/core/apimgt/application/extension/bean/ApiApplicationKey.java
@@ -19,7 +19,7 @@
 package io.entgra.device.mgt.core.apimgt.application.extension.bean;
 
 import io.entgra.device.mgt.core.apimgt.application.extension.constants.ApiApplicationConstants;
-import org.json.simple.JSONObject;
+import org.json.JSONObject;
 
 /**
  * This holds api application consumer key and secret.


### PR DESCRIPTION
## Purpose
https://roadmap.entgra.net/issues/12725

## Goals
Fix was done to resolve the following error.
Exception in thread "Thread-489" java.lang.NoClassDefFoundError: org/json/JSONObject
at io.entgra.device.mgt.core.apimgt.application.extension.APIManagementProviderServiceImpl.generateRequestBody(APIManagementProviderServiceImpl.java:98)
at io.entgra.device.mgt.core.apimgt.application.extension.APIManagementProviderServiceImpl.getToken(APIManagementProviderServiceImpl.java:427)
at io.entgra.device.mgt.plugins.input.adapter.mqtt.util.MQTTAdapterListener.getToken(MQTTAdapterListener.java:308)
at io.entgra.device.mgt.plugins.input.adapter.mqtt.util.MQTTAdapterListener.startListener(MQTTAdapterListener.java:149)
at io.entgra.device.mgt.plugins.input.adapter.mqtt.util.MQTTAdapterListener.run(MQTTAdapterListener.java:273)
at java.base/java.lang.Thread.run(Thread.java:834)

## Approach
This error comes , when in the deployment.toml following configuration is enabled and the server is started.
[device_mgt_conf.pull_notification_conf]
enabled=true

io.entgra.device.mgt.core.apimgt.application.extension.APIManagementProviderServiceImpl.getToken() has an indirect dependency on org.json.simple.JSONObject when org.json.simple.JSONObject is used in ApiApplicationKey, because:
It calls generateRequestBody(), which constructs a JSONObject.
The returned JSONObject is used to create the request body for fetching a token.
but getToken internally use org.json.JSONObject, thus the fix was provided as to use org.json.JSONObject also in ApiApplicationKey for use in the toString() method.