### PR TITLE
Add API endpoints for loading Loki Explore & Pyroscope plugin settings in grafanaAPIProxyService

### DIFF
--- a/components/analytics-mgt/grafana-mgt/io.entgra.device.mgt.core.analytics.mgt.grafana.proxy.api/src/main/java/io/entgra/device/mgt/core/analytics/mgt/grafana/proxy/api/GrafanaAPIProxyService.java
+++ b/components/analytics-mgt/grafana-mgt/io.entgra.device.mgt.core.analytics.mgt.grafana.proxy.api/src/main/java/io/entgra/device/mgt/core/analytics/mgt/grafana/proxy/api/GrafanaAPIProxyService.java
@@ -192,4 +192,40 @@ public interface GrafanaAPIProxyService {
             }
     )
     Response getAlertStateForDashboards(@Context HttpHeaders headers, @Context UriInfo requestUriInfo) throws ClassNotFoundException;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/plugins/grafana-lokiexplore-app/settings")
+    @ApiOperation(
+            produces = MediaType.APPLICATION_JSON,
+            httpMethod = "GET",
+            value = "Retrieve Grafana Loki Explore App settings",
+            tags = "Analytics",
+            extensions = {
+                    @Extension(properties = {
+                            @ExtensionProperty(name = SCOPE, value = "grafana:api:view")
+                    })
+            }
+    )
+    Response loadLokiExploreAppSettings(@Context HttpHeaders headers, @Context UriInfo requestUriInfo)
+            throws ClassNotFoundException;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/plugins/grafana-pyroscope-app/settings")
+    @ApiOperation(
+            produces = MediaType.APPLICATION_JSON,
+            httpMethod = "GET",
+            value = "Retrieve Grafana Pyroscope App settings",
+            tags = "Analytics",
+            extensions = {
+                    @Extension(properties = {
+                            @ExtensionProperty(name = SCOPE, value = "grafana:api:view")
+                    })
+            }
+    )
+    Response loadGrafanaPyroscopeSettings(@Context HttpHeaders headers, @Context UriInfo requestUriInfo)
+            throws ClassNotFoundException;
 }

--- a/components/analytics-mgt/grafana-mgt/io.entgra.device.mgt.core.analytics.mgt.grafana.proxy.api/src/main/java/io/entgra/device/mgt/core/analytics/mgt/grafana/proxy/api/impl/GrafanaAPIProxyServiceImpl.java
+++ b/components/analytics-mgt/grafana-mgt/io.entgra.device.mgt.core.analytics.mgt.grafana.proxy.api/src/main/java/io/entgra/device/mgt/core/analytics/mgt/grafana/proxy/api/impl/GrafanaAPIProxyServiceImpl.java
@@ -134,6 +134,24 @@ public class GrafanaAPIProxyServiceImpl implements GrafanaAPIProxyService {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/plugins/grafana-lokiexplore-app/settings")
+    @Override
+    public Response loadLokiExploreAppSettings(@Context HttpHeaders headers, @Context UriInfo requestUriInfo) {
+        return proxyPassGetRequest(headers, requestUriInfo);
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/plugins/grafana-pyroscope-app/settings")
+    @Override
+    public Response loadGrafanaPyroscopeSettings(@Context HttpHeaders headers, @Context UriInfo requestUriInfo) {
+        return proxyPassGetRequest(headers, requestUriInfo);
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("/alerts/states-for-dashboard")
     @Override
     public Response getAlertStateForDashboards(@Context HttpHeaders headers, @Context UriInfo requestUriInfo) {


### PR DESCRIPTION
## Purpose
> When setting up Grafana authentication configurations for embedded Grafana, the Loki Explore settings endpoint and Pyroscope settings API must be loaded during initialization. To ensure these requests are handled successfully, we need to integrate these APIs into the GrafanaAPIProxyService.



