### PR TITLE
Fix for subscription status not syncing from app store end

### DIFF
--- a/components/application-mgt/io.entgra.device.mgt.core.application.mgt.common/src/main/java/io/entgra/device/mgt/core/application/mgt/common/SubscriptionData.java
+++ b/components/application-mgt/io.entgra.device.mgt.core.application.mgt.common/src/main/java/io/entgra/device/mgt/core/application/mgt/common/SubscriptionData.java
@@ -27,6 +27,7 @@ public class SubscriptionData {
     private String subscriptionType;
     private Timestamp triggeredAt;
     private int subscriptionId;
+    private int operationId;
 
     public String getDeviceSubscriptionStatus() {
         return deviceSubscriptionStatus;
@@ -66,5 +67,12 @@ public class SubscriptionData {
 
     public void setSubscriptionId(int subscriptionId) {
         this.subscriptionId = subscriptionId;
+    }
+
+    public int getOperationId() {
+    return operationId;
+    }
+    public void setOperationId(int operationId) {
+        this.operationId = operationId;
     }
 }

--- a/components/application-mgt/io.entgra.device.mgt.core.application.mgt.common/src/main/java/io/entgra/device/mgt/core/application/mgt/common/dto/DeviceSubscriptionDTO.java
+++ b/components/application-mgt/io.entgra.device.mgt.core.application.mgt.common/src/main/java/io/entgra/device/mgt/core/application/mgt/common/dto/DeviceSubscriptionDTO.java
@@ -34,6 +34,7 @@ public class DeviceSubscriptionDTO {
     private int deviceId;
     private int appReleaseId;
     private String appUuid;
+    private int operationId;
 
     public DeviceSubscriptionDTO() {
 
@@ -134,6 +135,14 @@ public class DeviceSubscriptionDTO {
 
     public void setAppUuid(String appUuid) {
         this.appUuid = appUuid;
+    }
+
+    public int getOperationId() {
+        return operationId;
+    }
+
+    public void setOperationId(int operationId) {
+        this.operationId = operationId;
     }
 
     @Override

--- a/components/application-mgt/io.entgra.device.mgt.core.application.mgt.core/src/main/java/io/entgra/device/mgt/core/application/mgt/core/util/subscription/mgt/SubscriptionManagementHelperUtil.java
+++ b/components/application-mgt/io.entgra.device.mgt.core.application.mgt.core/src/main/java/io/entgra/device/mgt/core/application/mgt/core/util/subscription/mgt/SubscriptionManagementHelperUtil.java
@@ -113,6 +113,7 @@ public class SubscriptionManagementHelperUtil {
                 SubscriptionData subscriptionData = getSubscriptionData(isUnsubscribed, deviceSubscriptionDTO);
                 deviceSubscription.setSubscriptionData(subscriptionData);
                 deviceSubscriptions.add(deviceSubscription);
+
             }
         }
         return deviceSubscriptions;
@@ -133,6 +134,7 @@ public class SubscriptionManagementHelperUtil {
         subscriptionData.setDeviceSubscriptionStatus(deviceSubscriptionDTO.getStatus());
         subscriptionData.setSubscriptionType(deviceSubscriptionDTO.getActionTriggeredFrom());
         subscriptionData.setSubscriptionId(deviceSubscriptionDTO.getId());
+        subscriptionData.setOperationId(deviceSubscriptionDTO.getOperationId());
         return subscriptionData;
     }
 

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/impl/DeviceManagementServiceImpl.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/impl/DeviceManagementServiceImpl.java
@@ -1737,23 +1737,17 @@ public class DeviceManagementServiceImpl implements DeviceManagementService {
             Operation operation = DeviceMgtAPIUtils.validateOperationStatusBean(operationStatusBean);
             operation.setId(operationStatusBean.getOperationId());
             operation.setCode(operationStatusBean.getOperationCode());
+            DeviceMgtAPIUtils.getDeviceManagementService().updateOperation(device, operation);
 
-            switch (operation.getCode()) {
-                case MDMAppConstants.AndroidConstants.OPCODE_INSTALL_APPLICATION:
-                case MDMAppConstants.AndroidConstants.OPCODE_UNINSTALL_APPLICATION:
-                case MDMAppConstants.WindowsConstants.INSTALL_ENTERPRISE_APPLICATION:
-                case MDMAppConstants.WindowsConstants.UNINSTALL_ENTERPRISE_APPLICATION:
-                case MDMAppConstants.WindowsConstants.INSTALL_STORE_APPLICATION:
-                case MDMAppConstants.WindowsConstants.UNINSTALL_STORE_APPLICATION:
-                    DeviceMgtAPIUtils.getDeviceManagementService().updateOperation(device, operation);
-                    DeviceMgtAPIUtils.getApplicationManager().updateSubsStatus(
-                            device.getId(), operation.getId(), operation.getStatus().toString()
-                    );
-                    break;
-                default:
-                    String msg = "Unsupported operation code: " + operation.getCode();
-                    log.error(msg);
-                    return Response.status(Response.Status.BAD_REQUEST).entity(msg).build();
+            if (MDMAppConstants.AndroidConstants.OPCODE_INSTALL_APPLICATION.equals(operation.getCode()) ||
+                    MDMAppConstants.AndroidConstants.OPCODE_UNINSTALL_APPLICATION.equals(operation.getCode()) ||
+                    MDMAppConstants.WindowsConstants.INSTALL_ENTERPRISE_APPLICATION.equals(operation.getCode()) ||
+                    MDMAppConstants.WindowsConstants.UNINSTALL_ENTERPRISE_APPLICATION.equals(operation.getCode()) ||
+                    MDMAppConstants.WindowsConstants.INSTALL_STORE_APPLICATION.equals(operation.getCode()) ||
+                    MDMAppConstants.WindowsConstants.UNINSTALL_STORE_APPLICATION.equals(operation.getCode())){
+                DeviceMgtAPIUtils.getApplicationManager().updateSubsStatus(
+                        device.getId(), operation.getId(), operation.getStatus().toString()
+                );
             }
             return Response.status(Response.Status.OK).entity("OperationStatus updated successfully.").build();
         } catch (BadRequestException e) {
@@ -1775,6 +1769,7 @@ public class DeviceManagementServiceImpl implements DeviceManagementService {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(msg).build();
         }
     }
+
 
     @GET
     @Path("/filters")


### PR DESCRIPTION
This PR fixes an issue where status changes made from the App Store side were not reflected in the operation logs. Previously, only status updates from the operation logs were synced with the App Store. This update ensures bidirectional sync between both ends.