### PR TITLE
Optimize Device event definition update logic

### DIFF
--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/impl/DeviceEventManagementServiceImpl.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/impl/DeviceEventManagementServiceImpl.java
@@ -215,7 +215,8 @@ public class DeviceEventManagementServiceImpl implements DeviceEventManagementSe
         try {
             // Check if any devices are enrolled for this device type
             if (checkDeviceEnrollment(deviceType)) {
-                List<DeviceTypeEvent> existingEvents = fetchExistingEvents(deviceType);
+                List<DeviceTypeEvent> existingEvents = DeviceMgtAPIUtils.getDeviceTypeEventManagementProviderService().
+                        getDeviceTypeEventDefinitions(deviceType);
                 Map<String, DeviceTypeEvent> existingEventMap = mapByName(existingEvents);
                 Map<String, DeviceTypeEvent> incomingEventMap = mapByName(deviceTypeEvents);
                 List<DeviceTypeEvent> updatedEvents = new ArrayList<>();
@@ -284,16 +285,6 @@ public class DeviceEventManagementServiceImpl implements DeviceEventManagementSe
         return DeviceMgtAPIUtils.getDeviceManagementService().getDevicesByType(request).getRecordsTotal() > 0;
     }
 
-    /**
-     * Fetches the existing event definitions for the given device type from the device type event management service.
-     *
-     * @param deviceType the type of the device whose events need to be fetched
-     * @return a list of existing {@link DeviceTypeEvent} definitions
-     * @throws DeviceManagementException if an error occurs while accessing the event management service
-     */
-    private List<DeviceTypeEvent> fetchExistingEvents(String deviceType) throws DeviceManagementException {
-        return DeviceMgtAPIUtils.getDeviceTypeEventManagementProviderService().getDeviceTypeEventDefinitions(deviceType);
-    }
 
     /**
      * Persists the given list of event definitions for the specified device type.

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/type/event/mgt/Attribute.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/type/event/mgt/Attribute.java
@@ -20,6 +20,8 @@ package io.entgra.device.mgt.core.device.mgt.common.type.event.mgt;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.Objects;
+
 /**
  * Each attribute definition
  * Attributes : name, type
@@ -55,6 +57,20 @@ public class Attribute {
 
     public void setType(AttributeType type) {
         this.type = type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Attribute)) return false;
+        Attribute that = (Attribute) o;
+        return Objects.equals(name, that.name) &&
+                type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, type);
     }
 }
 

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/type/event/mgt/DeviceTypeEvent.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/type/event/mgt/DeviceTypeEvent.java
@@ -19,9 +19,10 @@ package io.entgra.device.mgt.core.device.mgt.common.type.event.mgt;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
 
 /**
- * This hold stats data record
+ * This hold device type event data record
  */
 public class DeviceTypeEvent {
 
@@ -70,6 +71,22 @@ public class DeviceTypeEvent {
 
     public void setEventName(String eventName) {
         this.eventName = eventName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DeviceTypeEvent)) return false;
+        DeviceTypeEvent that = (DeviceTypeEvent) o;
+        return Objects.equals(eventName, that.eventName) &&
+                Objects.equals(eventAttributes, that.eventAttributes) &&
+                transport == that.transport &&
+                Objects.equals(eventTopicStructure, that.eventTopicStructure);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventName, eventAttributes, transport, eventTopicStructure);
     }
 }
 

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/type/event/mgt/DeviceTypeEventUpdateResult.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/type/event/mgt/DeviceTypeEventUpdateResult.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018 - 2025, Entgra (Pvt) Ltd. (http://www.entgra.io) All Rights Reserved.
+ *
+ * Entgra (Pvt) Ltd. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.entgra.device.mgt.core.device.mgt.common.type.event.mgt;
+
+import java.util.List;
+
+public class DeviceTypeEventUpdateResult {
+    private final List<DeviceTypeEvent> updatedEvents;
+    private final List<DeviceTypeEvent> mergedEvents;
+
+    public DeviceTypeEventUpdateResult(List<DeviceTypeEvent> updatedEvents, List<DeviceTypeEvent> mergedEvents) {
+        this.updatedEvents = updatedEvents;
+        this.mergedEvents = mergedEvents;
+    }
+
+    public List<DeviceTypeEvent> getUpdatedEvents() {
+        return updatedEvents;
+    }
+
+    public List<DeviceTypeEvent> getMergedEvents() {
+        return mergedEvents;
+    }
+}
+

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/type/event/mgt/EventAttributeList.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/type/event/mgt/EventAttributeList.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * This holds event attributes
@@ -40,5 +41,17 @@ public class EventAttributeList {
         this.attributes = attributes;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EventAttributeList that = (EventAttributeList) o;
+        return Objects.equals(attributes, that.attributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(attributes);
+    }
 }
 

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/type/event/mgt/EventAttributeList.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/type/event/mgt/EventAttributeList.java
@@ -44,7 +44,7 @@ public class EventAttributeList {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof EventAttributeList)) return false;
         EventAttributeList that = (EventAttributeList) o;
         return Objects.equals(attributes, that.attributes);
     }

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/service/DeviceTypeEventManagementProviderService.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/service/DeviceTypeEventManagementProviderService.java
@@ -20,6 +20,8 @@ package io.entgra.device.mgt.core.device.mgt.core.service;
 
 import io.entgra.device.mgt.core.device.mgt.common.exceptions.DeviceManagementException;
 import io.entgra.device.mgt.core.device.mgt.common.type.event.mgt.DeviceTypeEvent;
+import io.entgra.device.mgt.core.device.mgt.common.type.event.mgt.DeviceTypeEventUpdateResult;
+
 import java.util.List;
 
 /**
@@ -84,4 +86,24 @@ public interface DeviceTypeEventManagementProviderService {
      * @throws DeviceManagementException If an error occurs during the deletion process.
      */
     boolean deleteDeviceTypeEventDefinitions(String deviceType) throws DeviceManagementException;
+
+    /**
+     * Computes the updated and merged device type event definitions for the given device type.
+     * <p>
+     * This method compares the incoming list of {@link DeviceTypeEvent} definitions with the existing ones
+     * for the specified device type. It identifies:
+     * <ul>
+     *     <li>Events that are new or modified ({@code updatedEvents})</li>
+     *     <li>Events that are unchanged or retained ({@code mergedEvents}, includes both updated and unchanged)</li>
+     * </ul>
+     * This is typically used to determine whether an update operation is needed and to construct the
+     * final event definition set to be persisted.
+     *
+     * @param deviceType      the name of the device type whose events are being updated
+     * @param incomingEvents  the list of incoming event definitions from the request
+     * @return a {@link DeviceTypeEventUpdateResult} containing lists of updated and merged events
+     * @throws DeviceManagementException if there is an error retrieving existing event definitions
+     */
+    DeviceTypeEventUpdateResult computeUpdatedDeviceTypeEvents(String deviceType, List<DeviceTypeEvent> incomingEvents)
+            throws DeviceManagementException;
 }


### PR DESCRIPTION
## Purpose
Device type event definition update logic is improved, to update based on event names if devices are already enrolled per device type. Complete removal of an added device type event is not possible (event name cannot be changed as it is used as the table creation name in event db and few other meta data at the moment)

##Ticket
https://roadmap.entgra.net/issues/13241