### PR TITLE
Add CustomOperation Class for building custom payloads for device ope…

### DIFF
--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/operation/mgt/CustomOperation.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/operation/mgt/CustomOperation.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018 - 2025, Entgra (Pvt) Ltd. (http://www.entgra.io) All Rights Reserved.
+ *
+ * Entgra (Pvt) Ltd. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.entgra.device.mgt.core.device.mgt.common.operation.mgt;
+
+import java.util.List;
+
+public class CustomOperation {
+    private Operation operation;
+    private List<String> deviceIds;
+
+    public Operation getOperation() {
+        return operation;
+    }
+
+    public void setOperation(Operation operation) {
+        this.operation = operation;
+    }
+
+    public List<String> getDeviceIds() {
+        return deviceIds;
+    }
+
+    public void setDeviceIds(List<String> deviceIds) {
+        this.deviceIds = deviceIds;
+    }
+}


### PR DESCRIPTION
## Purpose
> This feature was implemented to support sending custom device operation payloads from the DFRM service.
Resolves: https://roadmap.entgra.net/issues/13638

## Related PRs
> https://github.com/entgra-proprietary/product-dfrm/pull/97
https://github.com/entgra-proprietary/emm-proprietary-plugins/pull/215
