### PR TITLE
Add configuration for DFRM enabled tenants for login validation

### DIFF
--- a/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.extension.rest.api/src/main/java/io/entgra/device/mgt/core/apimgt/extension/rest/api/constants/Constants.java
+++ b/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.extension.rest.api/src/main/java/io/entgra/device/mgt/core/apimgt/extension/rest/api/constants/Constants.java
@@ -79,6 +79,7 @@ public final class Constants {
     public static final String PERM_SCOPE_MAPPING_META_KEY  = "perm-scope-mapping";
     public static final String PLACEHOLDING_CALLBACK_URL = HTTPS_PROTOCOL + SCHEME_SEPARATOR + "localhost";
     public static final String API_PUBLISHING_ENABLED_TENANT_LIST_KEY = "api-publishing-enabled-tenant-list";
+    public static final String DFRM_ENABLED_TENANT_LIST_KEY = "dfrm-enabled-tenant-list";
     public static final String IDN_DCR_CLIENT_PREFIX = "_REST_API_INVOKER_SERVICE";
     public static final String IDN_REST_API_INVOKER_USER = "rest_service_reserved_user";
     public static final String IDN_REST_API_INVOKER_USER_PWD = "rest_service_reserved_user";

--- a/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.webapp.publisher/src/main/java/io/entgra/device/mgt/core/apimgt/webapp/publisher/config/DfrmEnabledTenantsConfig.java
+++ b/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.webapp.publisher/src/main/java/io/entgra/device/mgt/core/apimgt/webapp/publisher/config/DfrmEnabledTenantsConfig.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2018 - 2025, Entgra (Pvt) Ltd. (http://www.entgra.io) All Rights Reserved.
+ *
+ * Entgra (Pvt) Ltd. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package io.entgra.device.mgt.core.apimgt.webapp.publisher.config;
+
+import io.entgra.device.mgt.core.apimgt.webapp.publisher.WebappPublisherConfigurationFailedException;
+import io.entgra.device.mgt.core.apimgt.webapp.publisher.WebappPublisherUtil;
+import org.w3c.dom.Document;
+import org.wso2.carbon.utils.CarbonUtils;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.io.File;
+
+@XmlRootElement(name = "DfrmEnabledTenantsConfig")
+public class DfrmEnabledTenantsConfig {
+    private Tenants tenants;
+    private static DfrmEnabledTenantsConfig config;
+    private static boolean isInitialized = false;
+    private static final String DFRM_ENABLED_TENANTS_CONFIG_PATH =
+            CarbonUtils.getCarbonConfigDirPath() + File.separator + "dfrm-tenants-config.xml";
+    private DfrmEnabledTenantsConfig() {}
+
+    public static DfrmEnabledTenantsConfig getInstance() {
+        if (!isInitialized) {
+            try {
+                init();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return config;
+    }
+
+    @XmlElement(name = "Tenants", required = true)
+    public Tenants getTenants() {
+        return tenants;
+    }
+
+    public void setTenants(Tenants tenants) {this.tenants = tenants;}
+
+    public synchronized static void init() throws WebappPublisherConfigurationFailedException {
+        if (isInitialized) {
+            return;
+        }
+        try {
+            File dfrmEnabledTenantConfig = new File(DFRM_ENABLED_TENANTS_CONFIG_PATH);
+            Document doc = WebappPublisherUtil.convertToDocument(dfrmEnabledTenantConfig);
+
+            JAXBContext ctx = JAXBContext.newInstance(DfrmEnabledTenantsConfig.class);
+            Unmarshaller unmarshaller = ctx.createUnmarshaller();
+            config = (DfrmEnabledTenantsConfig) unmarshaller.unmarshal(doc);
+            isInitialized = true;
+        } catch (JAXBException e) {
+            throw new WebappPublisherConfigurationFailedException("Error occurred while un-marshalling DFRM Enabled " +
+                    "Tenant Config", e);
+        }
+    }
+}

--- a/components/ui-request-interceptor/io.entgra.device.mgt.core.ui.request.interceptor/src/main/java/io/entgra/device/mgt/core/ui/request/interceptor/LoginHandler.java
+++ b/components/ui-request-interceptor/io.entgra.device.mgt.core.ui.request.interceptor/src/main/java/io/entgra/device/mgt/core/ui/request/interceptor/LoginHandler.java
@@ -128,6 +128,13 @@ public class LoginHandler extends HttpServlet {
                     return;
                 }
 
+                if (clientAppResponse.getCode() == HttpStatus.SC_INTERNAL_SERVER_ERROR) {
+                    log.error("API Application registration failed. Backend returned 500. " +
+                            "This might be due to DFRM validation failure.");
+                    HandlerUtil.handleError(resp, clientAppResponse);
+                    return;
+                }
+
                 if (clientAppResponse.getCode() == HttpStatus.SC_CREATED) {
                     JsonNode jsonNode = clientAppResponse.getData();
                     String clientId = null;
@@ -158,7 +165,7 @@ public class LoginHandler extends HttpServlet {
                         return;
                     }
                 }
-                HandlerUtil.handleError(resp, null);
+                HandlerUtil.handleError(resp, clientAppResponse);
             } else {
                 getTokenAndPersistInSession(req, resp, username, oAuthApp.getClientId(), oAuthApp.getClientSecret(),
                         oAuthApp.getEncodedClientApp(), scopes, HandlerConstants.SESSION_AUTH_DATA_KEY);

--- a/features/device-mgt/io.entgra.device.mgt.core.device.mgt.basics.feature/src/main/resources/conf/dfrm-tenants-config.xml
+++ b/features/device-mgt/io.entgra.device.mgt.core.device.mgt.basics.feature/src/main/resources/conf/dfrm-tenants-config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  ~ Copyright (c) 2018 - 2025, Entgra (Pvt) Ltd. (http://www.entgra.io) All Rights Reserved.
+  ~
+  ~ Entgra (Pvt) Ltd. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<DfrmEnabledTenantsConfig>
+    <!-- Apart from the super tenant, DFRM functionalities will be enabled to the following tenants -->
+    <Tenants>
+        <!-- <Tenant>example.com</Tenant> -->
+    </Tenants>
+</DfrmEnabledTenantsConfig>

--- a/features/device-mgt/io.entgra.device.mgt.core.device.mgt.basics.feature/src/main/resources/conf_templates/templates/repository/conf/dfrm-tenants-config.xml.j2
+++ b/features/device-mgt/io.entgra.device.mgt.core.device.mgt.basics.feature/src/main/resources/conf_templates/templates/repository/conf/dfrm-tenants-config.xml.j2
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+~ Copyright (c) 2018 - 2025, Entgra (Pvt) Ltd. (http://www.entgra.io) All Rights Reserved.
+~
+~ Entgra (Pvt) Ltd. licenses this file to you under the Apache License,
+~ Version 2.0 (the "License"); you may not use this file except
+~ in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~    http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing,
+~ software distributed under the License is distributed on an
+~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~ KIND, either express or implied. See the License for the
+~ specific language governing permissions and limitations
+~ under the License.
+-->
+
+<DfrmEnabledTenantsConfig>
+    <Tenants>
+       {% if dfrm_enabled_tenants.tenants is defined %}
+           {%- for tenant in dfrm_enabled_tenants.tenants -%}
+                <Tenant>{{tenant}}</Tenant>
+           {% endfor %}
+       {% endif %}
+    </Tenants>
+</DfrmEnabledTenantsConfig>


### PR DESCRIPTION
## Purpose
Resolves an error condition where users of "DFRM Enabled" tenants could register OAuth applications with zero subscriptions if they logged in before the administrator published the required Device Financial Risk Management (DFRM) APIs. This resulted in a cache state where subsequent logins would continue to use the empty subscription list, returning a 403 error even after APIs were published, requiring a server restart to fix.

## Approach

- Implement a validation step within the registerApiApplication method.
- The logic checks if the tenant is flagged as DFRM_ENABLED in the metadata.
- If enabled, it verifies if the DFRM APIs are actually published in the tenant's API Store.
- If validation fails (APIs missing), the method now throws an exception, aborting the application creation.

## Documentation
https://docs.google.com/document/d/13TwB6aPgcBOViBe9jtbokp14TG8OLa2BqqcuycnEyrc/edit?usp=sharing