### PR TITLE
Add support for Windows EXE applications

### DIFF
--- a/components/application-mgt/io.entgra.device.mgt.core.application.mgt.core/src/main/java/io/entgra/device/mgt/core/application/mgt/core/impl/ApplicationManagerImpl.java
+++ b/components/application-mgt/io.entgra.device.mgt.core.application.mgt.core/src/main/java/io/entgra/device/mgt/core/application/mgt/core/impl/ApplicationManagerImpl.java
@@ -880,9 +880,10 @@ public class ApplicationManagerImpl implements ApplicationManager {
                 String windowsInstallerName = applicationArtifact.getInstallerName();
                 String extension = windowsInstallerName.substring(windowsInstallerName.lastIndexOf(".") + 1);
                 if (!extension.equalsIgnoreCase(Constants.MSI) &&
-                        !extension.equalsIgnoreCase(Constants.APPX)) {
+                        !extension.equalsIgnoreCase(Constants.APPX) &&
+                        !extension.equalsIgnoreCase(Constants.EXE)) {
                     String msg = "Application Type doesn't match with supporting application types of " +
-                            deviceType + "platform which are APPX and MSI";
+                            deviceType + " platform which are APPX, MSI and EXE";
                     log.error(msg);
                     throw new BadRequestException(msg);
                 }

--- a/components/application-mgt/io.entgra.device.mgt.core.application.mgt.core/src/main/java/io/entgra/device/mgt/core/application/mgt/core/util/Constants.java
+++ b/components/application-mgt/io.entgra.device.mgt.core.application.mgt.core/src/main/java/io/entgra/device/mgt/core/application/mgt/core/util/Constants.java
@@ -96,6 +96,7 @@ public class Constants {
     //App type constants related to window device type
     public static final String MSI = "MSI";
     public static final String APPX = "APPX";
+    public static final String EXE = "EXE";
 
     public static final String ENTERPRISE_APP_TYPE = "ENTERPRISE";
     public static final String PUBLIC_APP_TYPE = "ENTERPRISE";

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/MDMAppConstants.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/MDMAppConstants.java
@@ -65,6 +65,7 @@ public class MDMAppConstants {
 		//App type constants related to window device type
 		public static final String MSI = "MSI";
 		public static final String APPX = "APPX";
+		public static final String EXE = "EXE";
 
 		//MSI Meta Key Constant
 		public static final String MSI_PRODUCT_ID = "Product_Id";

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/app/mgt/windows/EnterpriseApplication.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/app/mgt/windows/EnterpriseApplication.java
@@ -30,6 +30,7 @@ public class EnterpriseApplication implements Serializable {
 
     private HostedAppxApplication hostedAppxApplication;
     private HostedMSIApplication hostedMSIApplication;
+    private HostedExeApplication hostedExeApplication;
 
     public HostedAppxApplication getHostedAppxApplication() {
         return hostedAppxApplication;
@@ -45,6 +46,14 @@ public class EnterpriseApplication implements Serializable {
 
     public void setHostedMSIApplication(HostedMSIApplication hostedMSIApplication) {
         this.hostedMSIApplication = hostedMSIApplication;
+    }
+
+    public HostedExeApplication getHostedExeApplication() {
+        return hostedExeApplication;
+    }
+
+    public void setHostedExeApplication(HostedExeApplication hostedExeApplication) {
+        this.hostedExeApplication = hostedExeApplication;
     }
 
     public String toJSON() {

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/app/mgt/windows/HostedExeApplication.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.common/src/main/java/io/entgra/device/mgt/core/device/mgt/common/app/mgt/windows/HostedExeApplication.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018 - 2026, Entgra (Pvt) Ltd. (http://www.entgra.io) All Rights Reserved.
+ *
+ * Entgra (Pvt) Ltd. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package io.entgra.device.mgt.core.device.mgt.common.app.mgt.windows;
+
+public class HostedExeApplication {
+    private String contentUrl;
+    private String fileHash;
+    private String silentArg;
+
+    public String getContentUrl() {
+        return contentUrl;
+    }
+
+    public void setContentUrl(String contentUrl) {
+        this.contentUrl = contentUrl;
+    }
+
+    public String getFileHash() {
+        return fileHash;
+    }
+
+    public void setFileHash(String fileHash) {
+        this.fileHash = fileHash;
+    }
+
+    public String getSilentArg() {
+        return silentArg;
+    }
+
+    public void setSilentArg(String silentArg) {
+        this.silentArg = silentArg;
+    }
+}

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/util/MDMWindowsOperationUtil.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/util/MDMWindowsOperationUtil.java
@@ -28,6 +28,7 @@ import io.entgra.device.mgt.core.device.mgt.common.app.mgt.App;
 import io.entgra.device.mgt.core.device.mgt.common.app.mgt.windows.AppStoreApplication;
 import io.entgra.device.mgt.core.device.mgt.common.app.mgt.windows.EnterpriseApplication;
 import io.entgra.device.mgt.core.device.mgt.common.app.mgt.windows.HostedAppxApplication;
+import io.entgra.device.mgt.core.device.mgt.common.app.mgt.windows.HostedExeApplication;
 import io.entgra.device.mgt.core.device.mgt.common.app.mgt.windows.HostedMSIApplication;
 import io.entgra.device.mgt.core.device.mgt.common.app.mgt.windows.WebClipApplication;
 import io.entgra.device.mgt.core.device.mgt.common.exceptions.UnknownApplicationTypeException;
@@ -69,6 +70,8 @@ public class MDMWindowsOperationUtil {
                     enterpriseApplication.getHostedMSIApplication().setContentUrl(application.getLocation());
                 } else if (MDMAppConstants.WindowsConstants.APPX.equalsIgnoreCase(appType)) {
                     enterpriseApplication.getHostedAppxApplication().setPackageUri(application.getLocation());
+                } else if (MDMAppConstants.WindowsConstants.EXE.equalsIgnoreCase(appType)) {
+                    enterpriseApplication.getHostedExeApplication().setContentUrl(application.getLocation());
                 }
                 operation.setCode(MDMAppConstants.WindowsConstants.INSTALL_ENTERPRISE_APPLICATION);
                 operation.setPayLoad(enterpriseApplication.toJSON());
@@ -198,6 +201,18 @@ public class MDMWindowsOperationUtil {
                 }
             }
             enterpriseApplication.setHostedMSIApplication(hostedMSIApplication);
+        } else if (MDMAppConstants.WindowsConstants.EXE.equalsIgnoreCase(appType)) {
+            HostedExeApplication hostedExeApplication = new HostedExeApplication();
+
+            for (int i = 0; i < metaJsonArray.size(); i++) {
+                metaElement = metaJsonArray.get(i);
+                metaObject = metaElement.getAsJsonObject();
+
+               if (MDMAppConstants.WindowsConstants.MSI_FILE_HASH.equals(metaObject.get("key").getAsString())) {
+                    hostedExeApplication.setFileHash(metaObject.get("value").getAsString().trim());
+                }
+            }
+            enterpriseApplication.setHostedExeApplication(hostedExeApplication);
         }
     }
 


### PR DESCRIPTION
## Purpose
Add support for Windows EXE type applications.

## Approach
Updated the validation checks involved with the file type, Updated EnterpriseApplication class with the new HostedExeApplication type and set the content URL that would be sent in the operation payload to the installer path.

## Related PRs
https://github.com/entgra-proprietary/proprietary-commons/pull/68

## Related Issue Ticket
https://roadmap.entgra.net/issues/15834