### PR TITLE
Enforce authenticated-user context for notification actions and add bulk mark-all support

### DIFF
--- a/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.api/pom.xml
+++ b/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.api/pom.xml
@@ -183,5 +183,10 @@
             <artifactId>io.entgra.device.mgt.core.apimgt.annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.entgra.device.mgt.core</groupId>
+            <artifactId>io.entgra.device.mgt.core.notification.mgt.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.api/src/main/java/io/entgra/device/mgt/core/notification/mgt/api/impl/NotificationServiceImpl.java
+++ b/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.api/src/main/java/io/entgra/device/mgt/core/notification/mgt/api/impl/NotificationServiceImpl.java
@@ -82,9 +82,10 @@ public class NotificationServiceImpl implements NotificationService {
             if (request == null) {
                 return Response.status(HttpStatus.SC_BAD_REQUEST).entity("Request body is required").build();
             }
+            String authenticatedUser = NotificationManagementApiUtil.getAuthenticatedUser();
             PaginatedUserNotificationResponse response =
                     notificationService.getUserNotificationsWithStatus(
-                            request.getUsername(), request.getLimit(), request.getOffset(), request.getIsRead());
+                            authenticatedUser, request.getLimit(), request.getOffset(), request.getIsRead());
             return Response.status(HttpStatus.SC_OK).entity(response).build();
         } catch (NotificationManagementException e) {
             String msg = "Failed to retrieve user notifications with status.";
@@ -102,13 +103,35 @@ public class NotificationServiceImpl implements NotificationService {
             if (request == null) {
                 return Response.status(HttpStatus.SC_BAD_REQUEST).entity("Request body is required").build();
             }
+            String authenticatedUser = NotificationManagementApiUtil.getAuthenticatedUser();
             notificationService.updateNotificationActionForUser(
-                    request.getNotificationIds(), request.getUsername(), request.isRead());
+                    request.getNotificationIds(), authenticatedUser, request.isRead());
             String status = request.isRead() ? "READ" : "UNREAD";
             return Response.status(HttpStatus.SC_OK)
                     .entity("Notification(s) marked as " + status).build();
         } catch (NotificationManagementException e) {
             String msg = "Failed to update notification action.";
+            log.error(msg, e);
+            return Response.status(HttpStatus.SC_INTERNAL_SERVER_ERROR).entity(msg).build();
+        }
+    }
+
+    @PUT
+    @Path("/action/all")
+    public Response updateAllNotificationAction(NotificationActionRequest request) {
+        NotificationManagementService notificationService =
+                NotificationManagementApiUtil.getNotificationManagementService();
+        try {
+            if (request == null) {
+                return Response.status(HttpStatus.SC_BAD_REQUEST).entity("Request body is required").build();
+            }
+            String authenticatedUser = NotificationManagementApiUtil.getAuthenticatedUser();
+            notificationService.updateAllNotificationActionForUser(authenticatedUser, request.isRead());
+            String status = request.isRead() ? "READ" : "UNREAD";
+            return Response.status(HttpStatus.SC_OK)
+                    .entity("All notifications marked as " + status).build();
+        } catch (NotificationManagementException e) {
+            String msg = "Failed to update all notification actions.";
             log.error(msg, e);
             return Response.status(HttpStatus.SC_INTERNAL_SERVER_ERROR).entity(msg).build();
         }
@@ -126,8 +149,9 @@ public class NotificationServiceImpl implements NotificationService {
             if (request == null) {
                 return Response.status(HttpStatus.SC_BAD_REQUEST).entity("Request body is required").build();
             }
+            String authenticatedUser = NotificationManagementApiUtil.getAuthenticatedUser();
             Map<String, List<Integer>> result = notificationService.deleteUserNotifications(
-                    request.getNotificationIds(), request.getUsername());
+                    request.getNotificationIds(), authenticatedUser);
             return Response.status(HttpStatus.SC_OK).entity(result).build();
         } catch (NotificationManagementException e) {
             String msg = "Failed to delete selected notifications.";
@@ -146,7 +170,8 @@ public class NotificationServiceImpl implements NotificationService {
             if (request == null) {
                 return Response.status(HttpStatus.SC_BAD_REQUEST).entity("Request body is required").build();
             }
-            notificationService.deleteAllUserNotifications(request.getUsername());
+            String authenticatedUser = NotificationManagementApiUtil.getAuthenticatedUser();
+            notificationService.deleteAllUserNotifications(authenticatedUser);
             String msg = "All notifications deleted successfully";
             return Response.status(HttpStatus.SC_OK).entity(msg).build();
         } catch (NotificationManagementException e) {
@@ -167,8 +192,9 @@ public class NotificationServiceImpl implements NotificationService {
             if (request == null) {
                 return Response.status(HttpStatus.SC_BAD_REQUEST).entity("Request body is required").build();
             }
+            String authenticatedUser = NotificationManagementApiUtil.getAuthenticatedUser();
             Map<String, List<Integer>> result = notificationService.archiveUserNotifications(
-                    request.getNotificationIds(), request.getUsername());
+                    request.getNotificationIds(), authenticatedUser);
             return Response.status(HttpStatus.SC_OK).entity(result).build();
         } catch (NotificationArchivalException e) {
             String msg = "Error archiving selected notifications.";
@@ -188,7 +214,8 @@ public class NotificationServiceImpl implements NotificationService {
             if (request == null) {
                 return Response.status(HttpStatus.SC_BAD_REQUEST).entity("Request body is required").build();
             }
-            notificationService.archiveAllUserNotifications(request.getUsername());
+            String authenticatedUser = NotificationManagementApiUtil.getAuthenticatedUser();
+            notificationService.archiveAllUserNotifications(authenticatedUser);
             String msg = "All notifications archived successfully";
             return Response.status(HttpStatus.SC_OK).entity(msg).build();
         } catch (NotificationArchivalException e) {

--- a/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.api/src/main/java/io/entgra/device/mgt/core/notification/mgt/api/impl/NotificationServiceImpl.java
+++ b/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.api/src/main/java/io/entgra/device/mgt/core/notification/mgt/api/impl/NotificationServiceImpl.java
@@ -21,10 +21,10 @@ package io.entgra.device.mgt.core.notification.mgt.api.impl;
 
 import io.entgra.device.mgt.core.notification.mgt.api.beans.NotificationActionRequest;
 import io.entgra.device.mgt.core.notification.mgt.api.beans.UserNotificationsRequest;
-import io.entgra.device.mgt.core.notification.mgt.api.beans.UsernameRequest;
 import io.entgra.device.mgt.core.notification.mgt.api.beans.UsernameWithNotificationIdsRequest;
 import io.entgra.device.mgt.core.notification.mgt.api.service.NotificationService;
 import io.entgra.device.mgt.core.notification.mgt.api.util.NotificationManagementApiUtil;
+import io.entgra.device.mgt.core.notification.mgt.core.util.NotificationHelper;
 import io.entgra.device.mgt.core.notification.mgt.common.dto.Notification;
 import io.entgra.device.mgt.core.notification.mgt.common.dto.PaginatedUserNotificationResponse;
 import io.entgra.device.mgt.core.notification.mgt.common.exception.NotificationArchivalException;
@@ -82,7 +82,7 @@ public class NotificationServiceImpl implements NotificationService {
             if (request == null) {
                 return Response.status(HttpStatus.SC_BAD_REQUEST).entity("Request body is required").build();
             }
-            String authenticatedUser = NotificationManagementApiUtil.getAuthenticatedUser();
+            String authenticatedUser = NotificationHelper.getAuthenticatedUser();
             PaginatedUserNotificationResponse response =
                     notificationService.getUserNotificationsWithStatus(
                             authenticatedUser, request.getLimit(), request.getOffset(), request.getIsRead());
@@ -103,7 +103,7 @@ public class NotificationServiceImpl implements NotificationService {
             if (request == null) {
                 return Response.status(HttpStatus.SC_BAD_REQUEST).entity("Request body is required").build();
             }
-            String authenticatedUser = NotificationManagementApiUtil.getAuthenticatedUser();
+            String authenticatedUser = NotificationHelper.getAuthenticatedUser();
             notificationService.updateNotificationActionForUser(
                     request.getNotificationIds(), authenticatedUser, request.isRead());
             String status = request.isRead() ? "READ" : "UNREAD";
@@ -118,16 +118,13 @@ public class NotificationServiceImpl implements NotificationService {
 
     @PUT
     @Path("/action/all")
-    public Response updateAllNotificationAction(NotificationActionRequest request) {
+    public Response updateAllNotificationAction(@QueryParam("read") boolean isRead) {
         NotificationManagementService notificationService =
                 NotificationManagementApiUtil.getNotificationManagementService();
         try {
-            if (request == null) {
-                return Response.status(HttpStatus.SC_BAD_REQUEST).entity("Request body is required").build();
-            }
-            String authenticatedUser = NotificationManagementApiUtil.getAuthenticatedUser();
-            notificationService.updateAllNotificationActionForUser(authenticatedUser, request.isRead());
-            String status = request.isRead() ? "READ" : "UNREAD";
+            String authenticatedUser = NotificationHelper.getAuthenticatedUser();
+            notificationService.updateAllNotificationActionForUser(authenticatedUser, isRead);
+            String status = isRead ? "READ" : "UNREAD";
             return Response.status(HttpStatus.SC_OK)
                     .entity("All notifications marked as " + status).build();
         } catch (NotificationManagementException e) {
@@ -149,7 +146,7 @@ public class NotificationServiceImpl implements NotificationService {
             if (request == null) {
                 return Response.status(HttpStatus.SC_BAD_REQUEST).entity("Request body is required").build();
             }
-            String authenticatedUser = NotificationManagementApiUtil.getAuthenticatedUser();
+            String authenticatedUser = NotificationHelper.getAuthenticatedUser();
             Map<String, List<Integer>> result = notificationService.deleteUserNotifications(
                     request.getNotificationIds(), authenticatedUser);
             return Response.status(HttpStatus.SC_OK).entity(result).build();
@@ -163,16 +160,17 @@ public class NotificationServiceImpl implements NotificationService {
     @DELETE
     @Path("/user-notifications/all")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response deleteAllNotifications(UsernameRequest request) {
+    public Response deleteAllNotifications(
+            @QueryParam("read") Boolean isRead) {
         NotificationManagementService notificationService =
                 NotificationManagementApiUtil.getNotificationManagementService();
         try {
-            if (request == null) {
-                return Response.status(HttpStatus.SC_BAD_REQUEST).entity("Request body is required").build();
-            }
-            String authenticatedUser = NotificationManagementApiUtil.getAuthenticatedUser();
-            notificationService.deleteAllUserNotifications(authenticatedUser);
+            String authenticatedUser = NotificationHelper.getAuthenticatedUser();
+            notificationService.deleteAllUserNotifications(authenticatedUser, isRead);
             String msg = "All notifications deleted successfully";
+            if (isRead != null) {
+                msg = isRead ? "All read notifications deleted successfully" : "All unread notifications deleted successfully";
+            }
             return Response.status(HttpStatus.SC_OK).entity(msg).build();
         } catch (NotificationManagementException e) {
             String msg = "Failed to delete all notifications.";
@@ -192,12 +190,16 @@ public class NotificationServiceImpl implements NotificationService {
             if (request == null) {
                 return Response.status(HttpStatus.SC_BAD_REQUEST).entity("Request body is required").build();
             }
-            String authenticatedUser = NotificationManagementApiUtil.getAuthenticatedUser();
+            String authenticatedUser = NotificationHelper.getAuthenticatedUser();
             Map<String, List<Integer>> result = notificationService.archiveUserNotifications(
                     request.getNotificationIds(), authenticatedUser);
             return Response.status(HttpStatus.SC_OK).entity(result).build();
         } catch (NotificationArchivalException e) {
             String msg = "Error archiving selected notifications.";
+            log.error(msg, e);
+            return Response.status(HttpStatus.SC_INTERNAL_SERVER_ERROR).entity(msg).build();
+        } catch (NotificationManagementException e) {
+            String msg = "Error occurred while getting authenticated user.";
             log.error(msg, e);
             return Response.status(HttpStatus.SC_INTERNAL_SERVER_ERROR).entity(msg).build();
         }
@@ -207,19 +209,20 @@ public class NotificationServiceImpl implements NotificationService {
     @Path("/archive-all")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response archiveAllNotifications(UsernameRequest request) {
+    public Response archiveAllNotifications() {
         NotificationManagementService notificationService =
                 NotificationManagementApiUtil.getNotificationManagementService();
         try {
-            if (request == null) {
-                return Response.status(HttpStatus.SC_BAD_REQUEST).entity("Request body is required").build();
-            }
-            String authenticatedUser = NotificationManagementApiUtil.getAuthenticatedUser();
+            String authenticatedUser = NotificationHelper.getAuthenticatedUser();
             notificationService.archiveAllUserNotifications(authenticatedUser);
             String msg = "All notifications archived successfully";
             return Response.status(HttpStatus.SC_OK).entity(msg).build();
         } catch (NotificationArchivalException e) {
             String msg = "Error archiving all notifications.";
+            log.error(msg, e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(msg).build();
+        } catch (NotificationManagementException e) {
+            String msg = "Error occurred while getting authenticated user.";
             log.error(msg, e);
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(msg).build();
         }

--- a/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.api/src/main/java/io/entgra/device/mgt/core/notification/mgt/api/service/NotificationService.java
+++ b/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.api/src/main/java/io/entgra/device/mgt/core/notification/mgt/api/service/NotificationService.java
@@ -238,6 +238,44 @@ public interface NotificationService {
             NotificationActionRequest request
     );
 
+    @PUT
+    @Path("/action/all")
+    @ApiOperation(
+            produces = MediaType.APPLICATION_JSON,
+            httpMethod = "PUT",
+            value = "Update All Notification Actions",
+            notes = "Mark all notifications as READ or UNREAD for a given user.",
+            tags = "Notification Management",
+            extensions = {
+                    @Extension(properties = {
+                            @ExtensionProperty(name = SCOPE, value = "dm:notif:mark-checked")
+                    })
+            }
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            code = 200,
+                            message = "OK. Successfully updated all notification actions.",
+                            response = Response.class),
+                    @ApiResponse(
+                            code = 400,
+                            message = "Bad Request. Missing or invalid parameters.",
+                            response = Response.class),
+                    @ApiResponse(
+                            code = 500,
+                            message = "Internal Server Error. Failed to update notification actions.",
+                            response = Response.class)
+            }
+    )
+    Response updateAllNotificationAction(
+            @ApiParam(
+                    name = "request",
+                    value = "Request body containing isRead",
+                    required = true)
+            NotificationActionRequest request
+    );
+
     @DELETE
     @Path("/user-notifications")
     @ApiOperation(

--- a/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.api/src/main/java/io/entgra/device/mgt/core/notification/mgt/api/service/NotificationService.java
+++ b/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.api/src/main/java/io/entgra/device/mgt/core/notification/mgt/api/service/NotificationService.java
@@ -270,10 +270,10 @@ public interface NotificationService {
     )
     Response updateAllNotificationAction(
             @ApiParam(
-                    name = "request",
-                    value = "Request body containing isRead",
+                    name = "read",
+                    value = "Boolean flag to mark all notifications as read or unread",
                     required = true)
-            NotificationActionRequest request
+            @QueryParam("read") boolean isRead
     );
 
     @DELETE
@@ -346,10 +346,10 @@ public interface NotificationService {
     )
     Response deleteAllNotifications(
             @ApiParam(
-                    name = "request",
-                    value = "Request body containing username",
-                    required = true)
-            UsernameRequest request
+                    name = "read",
+                    value = "Optional boolean flag to delete only read or unread notifications. If not provided, all notifications will be deleted.",
+                    required = false)
+            @QueryParam("read") Boolean isRead
     );
 
     @POST
@@ -421,12 +421,6 @@ public interface NotificationService {
                             response = Response.class)
             }
     )
-    Response archiveAllNotifications(
-            @ApiParam(
-                    name = "request",
-                    value = "Request body containing username",
-                    required = true)
-            UsernameRequest request
-    );
+    Response archiveAllNotifications();
 
 }

--- a/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.api/src/main/java/io/entgra/device/mgt/core/notification/mgt/api/util/NotificationManagementApiUtil.java
+++ b/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.api/src/main/java/io/entgra/device/mgt/core/notification/mgt/api/util/NotificationManagementApiUtil.java
@@ -40,4 +40,13 @@ public class NotificationManagementApiUtil {
         }
         return notificationManagementService;
     }
+
+    /**
+     * Gets the authenticated username from the thread-local Carbon Context.
+     * @return String authenticated username
+     */
+    public static String getAuthenticatedUser() {
+        PrivilegedCarbonContext ctx = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+        return ctx.getUsername();
+    }
 }

--- a/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.api/src/main/java/io/entgra/device/mgt/core/notification/mgt/api/util/NotificationManagementApiUtil.java
+++ b/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.api/src/main/java/io/entgra/device/mgt/core/notification/mgt/api/util/NotificationManagementApiUtil.java
@@ -41,12 +41,4 @@ public class NotificationManagementApiUtil {
         return notificationManagementService;
     }
 
-    /**
-     * Gets the authenticated username from the thread-local Carbon Context.
-     * @return String authenticated username
-     */
-    public static String getAuthenticatedUser() {
-        PrivilegedCarbonContext ctx = PrivilegedCarbonContext.getThreadLocalCarbonContext();
-        return ctx.getUsername();
-    }
 }

--- a/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.common/src/main/java/io/entgra/device/mgt/core/notification/mgt/common/service/NotificationManagementService.java
+++ b/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.common/src/main/java/io/entgra/device/mgt/core/notification/mgt/common/service/NotificationManagementService.java
@@ -64,6 +64,17 @@ public interface NotificationManagementService {
             throws NotificationManagementException;
 
     /**
+     * Updates the action type (e.g., READ or UNREAD) for all notifications
+     * for a specific user and pushes the updated unread count.
+     *
+     * @param username Username for whom the actions are to be updated.
+     * @param isRead   Action type to set (e.g., "READ", "UNREAD").
+     * @throws NotificationManagementException If an error occurs while processing the update.
+     */
+    void updateAllNotificationActionForUser(String username, boolean isRead)
+            throws NotificationManagementException;
+
+    /**
      * Retrieves the total number of user notification actions for a specific user,
      * optionally filtered by notification status.
      *

--- a/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.common/src/main/java/io/entgra/device/mgt/core/notification/mgt/common/service/NotificationManagementService.java
+++ b/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.common/src/main/java/io/entgra/device/mgt/core/notification/mgt/common/service/NotificationManagementService.java
@@ -114,11 +114,13 @@ public interface NotificationManagementService {
 
     /**
      * Deletes all notifications for the given user from the active user notification table.
+     * Optionally filters by read/unread status.
      *
      * @param username the username whose notifications should be deleted.
+     * @param isRead   filter by read/unread status; if null, both read and unread notifications are deleted
      * @throws NotificationManagementException if an error occurs during the deletion process.
      */
-    void deleteAllUserNotifications(String username) throws NotificationManagementException;
+    void deleteAllUserNotifications(String username, Boolean isRead) throws NotificationManagementException;
 
     /**
      * Archives all notifications for the given user by moving them from the active

--- a/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.core/src/main/java/io/entgra/device/mgt/core/notification/mgt/core/dao/AbstractNotificationManagementDAOImpl.java
+++ b/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.core/src/main/java/io/entgra/device/mgt/core/notification/mgt/core/dao/AbstractNotificationManagementDAOImpl.java
@@ -214,6 +214,27 @@ public class AbstractNotificationManagementDAOImpl implements NotificationManage
     }
 
     @Override
+    public void updateAllNotificationAction(String username, boolean isRead)
+            throws NotificationManagementDAOException {
+        String query =
+                "UPDATE DM_NOTIFICATION_USER_ACTION " +
+                        "SET IS_READ = ? " +
+                        "WHERE USERNAME = ?";
+        try {
+            Connection connection = NotificationManagementDAOFactory.getConnection();
+            try (PreparedStatement ps = connection.prepareStatement(query)) {
+                ps.setBoolean(1, isRead);
+                ps.setString(2, username);
+                ps.executeUpdate();
+            }
+        } catch (SQLException e) {
+            String msg = "Error occurred while updating all notification actions for user: " + username;
+            log.error(msg, e);
+            throw new NotificationManagementDAOException(msg, e);
+        }
+    }
+
+    @Override
     public List<UserNotificationAction> getAllNotificationUserActions() throws NotificationManagementDAOException {
         List<UserNotificationAction> userNotificationActions = new ArrayList<>();
         String query =

--- a/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.core/src/main/java/io/entgra/device/mgt/core/notification/mgt/core/dao/AbstractNotificationManagementDAOImpl.java
+++ b/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.core/src/main/java/io/entgra/device/mgt/core/notification/mgt/core/dao/AbstractNotificationManagementDAOImpl.java
@@ -187,6 +187,7 @@ public class AbstractNotificationManagementDAOImpl implements NotificationManage
         if (notificationIds == null || notificationIds.isEmpty()) {
             return;
         }
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
         String placeholders = notificationIds.stream()
                 .map(id -> "?")
                 .collect(Collectors.joining(", "));
@@ -195,7 +196,9 @@ public class AbstractNotificationManagementDAOImpl implements NotificationManage
                         "SET IS_READ = ? " +
                         "WHERE USERNAME = ? " +
                         "AND NOTIFICATION_ID " +
-                        "IN (" + placeholders + ")";
+                        "IN (" + placeholders + ") " +
+                        "AND NOTIFICATION_ID IN " +
+                        "(SELECT NOTIFICATION_ID FROM DM_NOTIFICATION WHERE TENANT_ID = ?)";
         try {
             Connection connection = NotificationManagementDAOFactory.getConnection();
             try (PreparedStatement ps = connection.prepareStatement(query)) {
@@ -204,6 +207,7 @@ public class AbstractNotificationManagementDAOImpl implements NotificationManage
                 for (int i = 0; i < notificationIds.size(); i++) {
                     ps.setInt(i + 3, notificationIds.get(i));
                 }
+                ps.setInt(notificationIds.size() + 3, tenantId);
                 ps.executeUpdate();
             }
         } catch (SQLException e) {
@@ -216,15 +220,19 @@ public class AbstractNotificationManagementDAOImpl implements NotificationManage
     @Override
     public void updateAllNotificationAction(String username, boolean isRead)
             throws NotificationManagementDAOException {
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
         String query =
                 "UPDATE DM_NOTIFICATION_USER_ACTION " +
                         "SET IS_READ = ? " +
-                        "WHERE USERNAME = ?";
+                        "WHERE USERNAME = ? " +
+                        "AND NOTIFICATION_ID IN " +
+                        "(SELECT NOTIFICATION_ID FROM DM_NOTIFICATION WHERE TENANT_ID = ?)";
         try {
             Connection connection = NotificationManagementDAOFactory.getConnection();
             try (PreparedStatement ps = connection.prepareStatement(query)) {
                 ps.setBoolean(1, isRead);
                 ps.setString(2, username);
+                ps.setInt(3, tenantId);
                 ps.executeUpdate();
             }
         } catch (SQLException e) {
@@ -457,15 +465,30 @@ public class AbstractNotificationManagementDAOImpl implements NotificationManage
     }
 
     @Override
-    public void deleteAllUserNotifications(String username) throws NotificationManagementDAOException {
-        String query =
+    public void deleteAllUserNotifications(String username, Boolean isRead) throws NotificationManagementDAOException {
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+        StringBuilder query = new StringBuilder(
                 "DELETE " +
                         "FROM DM_NOTIFICATION_USER_ACTION " +
-                        "WHERE USERNAME = ?";
+                        "WHERE USERNAME = ? " +
+                        "AND NOTIFICATION_ID IN " +
+                        "(SELECT NOTIFICATION_ID FROM DM_NOTIFICATION WHERE TENANT_ID = ?)");
+
+        if (isRead != null) {
+            query.append(" AND IS_READ = ?");
+        }
+
         try {
             Connection connection = NotificationManagementDAOFactory.getConnection();
-            try (PreparedStatement stmt = connection.prepareStatement(query)) {
-                stmt.setString(1, username);
+            try (PreparedStatement stmt = connection.prepareStatement(query.toString())) {
+                int paramIndex = 1;
+                stmt.setString(paramIndex++, username);
+                stmt.setInt(paramIndex++, tenantId);
+                
+                if (isRead != null) {
+                    stmt.setBoolean(paramIndex++, isRead);
+                }
+                
                 stmt.executeUpdate();
             }
         } catch (SQLException e) {

--- a/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.core/src/main/java/io/entgra/device/mgt/core/notification/mgt/core/dao/NotificationManagementDAO.java
+++ b/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.core/src/main/java/io/entgra/device/mgt/core/notification/mgt/core/dao/NotificationManagementDAO.java
@@ -77,6 +77,17 @@ public interface NotificationManagementDAO {
             throws NotificationManagementDAOException;
 
     /**
+     * Updates the action type (e.g., READ or UNREAD) for all notifications
+     * for the given user.
+     *
+     * @param username    Username for whom the actions are to be updated.
+     * @param isRead      Action type to set (e.g., "READ", "UNREAD").
+     * @throws NotificationManagementDAOException If an error occurs while updating the notifications.
+     */
+    void updateAllNotificationAction(String username, boolean isRead)
+            throws NotificationManagementDAOException;
+
+    /**
      * Retrieves all notification actions performed by all users.
      *
      * @return a list of {@link UserNotificationAction} objects representing actions taken by users

--- a/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.core/src/main/java/io/entgra/device/mgt/core/notification/mgt/core/dao/NotificationManagementDAO.java
+++ b/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.core/src/main/java/io/entgra/device/mgt/core/notification/mgt/core/dao/NotificationManagementDAO.java
@@ -155,11 +155,13 @@ public interface NotificationManagementDAO {
 
     /**
      * Deletes all notifications for the given user from the active user notification table.
+     * Optionally filters by read/unread status.
      *
      * @param username the username whose notifications should be deleted.
+     * @param isRead   filter by read/unread status; if null, both read and unread notifications are deleted
      * @throws NotificationManagementDAOException if an error occurs during the deletion process.
      */
-    void deleteAllUserNotifications(String username) throws NotificationManagementDAOException;
+    void deleteAllUserNotifications(String username, Boolean isRead) throws NotificationManagementDAOException;
 
     /**
      * Retrieves a paginated list of user notifications along with their read/unread status.

--- a/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.core/src/main/java/io/entgra/device/mgt/core/notification/mgt/core/impl/NotificationManagementServiceImpl.java
+++ b/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.core/src/main/java/io/entgra/device/mgt/core/notification/mgt/core/impl/NotificationManagementServiceImpl.java
@@ -81,7 +81,6 @@ public class NotificationManagementServiceImpl implements NotificationManagement
     @Override
     public PaginatedUserNotificationResponse getUserNotificationsWithStatus(
             String username, int limit, int offset, Boolean isRead) throws NotificationManagementException {
-        username = NotificationHelper.getTenantAwareUsernameIfUserExists(username);
         try {
             NotificationManagementDAOFactory.openConnection();
             return notificationDAO.getUserNotificationsWithStatus(username, limit, offset, isRead);
@@ -101,15 +100,14 @@ public class NotificationManagementServiceImpl implements NotificationManagement
     @Override
     public void updateNotificationActionForUser(List<Integer> notificationIds, String username, boolean isRead)
             throws NotificationManagementException {
-        username = NotificationHelper.getTenantAwareUsernameIfUserExists(username);
+        int unreadCount = 0;
         try {
             NotificationManagementDAOFactory.beginTransaction();
             notificationDAO.updateNotificationAction(notificationIds, username, isRead);
+            unreadCount = notificationDAO.getUnreadNotificationCountForUser(username);
             NotificationManagementDAOFactory.commitTransaction();
-            int unreadCount = notificationDAO.getUnreadNotificationCountForUser(username);
-            String payload = String.format("{\"unreadCount\":%d}", unreadCount);
-            NotificationEventBroker.pushMessage(payload, Collections.singletonList(username));
         } catch (NotificationManagementDAOException e) {
+            NotificationManagementDAOFactory.rollbackTransaction();
             String msg = "Error occurred while updating notification actions";
             log.error(msg, e);
             throw new NotificationManagementException(msg, e);
@@ -121,20 +119,25 @@ public class NotificationManagementServiceImpl implements NotificationManagement
         } finally {
             NotificationManagementDAOFactory.closeConnection();
         }
+        String payload = String.format("{\"unreadCount\":%d}", unreadCount);
+        try {
+            NotificationEventBroker.pushMessage(payload, Collections.singletonList(username));
+        } catch (Exception e) {
+            log.error("Error occurred while pushing unread notification count to user: " + username, e);
+        }
     }
 
     @Override
     public void updateAllNotificationActionForUser(String username, boolean isRead)
             throws NotificationManagementException {
-        username = NotificationHelper.getTenantAwareUsernameIfUserExists(username);
+        int unreadCount = 0;
         try {
             NotificationManagementDAOFactory.beginTransaction();
             notificationDAO.updateAllNotificationAction(username, isRead);
+            unreadCount = notificationDAO.getUnreadNotificationCountForUser(username);
             NotificationManagementDAOFactory.commitTransaction();
-            int unreadCount = notificationDAO.getUnreadNotificationCountForUser(username);
-            String payload = String.format("{\"unreadCount\":%d}", unreadCount);
-            NotificationEventBroker.pushMessage(payload, Collections.singletonList(username));
         } catch (NotificationManagementDAOException e) {
+            NotificationManagementDAOFactory.rollbackTransaction();
             String msg = "Error occurred while updating all notification actions";
             log.error(msg, e);
             throw new NotificationManagementException(msg, e);
@@ -146,12 +149,18 @@ public class NotificationManagementServiceImpl implements NotificationManagement
         } finally {
             NotificationManagementDAOFactory.closeConnection();
         }
+        
+        String payload = String.format("{\"unreadCount\":%d}", unreadCount);
+        try {
+            NotificationEventBroker.pushMessage(payload, Collections.singletonList(username));
+        } catch (Exception e) {
+            log.error("Error occurred while pushing unread notification count to user: " + username, e);
+        }
     }
 
     @Override
     public int getUserNotificationCount(String username, Boolean isRead) throws NotificationManagementException {
         try {
-            username = NotificationHelper.getTenantAwareUsernameIfUserExists(username);
             NotificationManagementDAOFactory.openConnection();
             return notificationDAO.getNotificationActionsCountByUser(username, isRead);
         } catch (SQLException e) {
@@ -170,15 +179,13 @@ public class NotificationManagementServiceImpl implements NotificationManagement
     @Override
     public Map<String, List<Integer>> deleteUserNotifications(List<Integer> notificationIds, String username)
             throws NotificationManagementException {
-        username = NotificationHelper.getTenantAwareUsernameIfUserExists(username);
+        Map<String, List<Integer>> result = null;
+        int unreadCount = 0;
         try {
             NotificationManagementDAOFactory.beginTransaction();
-            Map<String, List<Integer>> result = notificationDAO.deleteUserNotifications(notificationIds, username);
+            result = notificationDAO.deleteUserNotifications(notificationIds, username);
+            unreadCount = notificationDAO.getUnreadNotificationCountForUser(username);
             NotificationManagementDAOFactory.commitTransaction();
-            int unreadCount = notificationDAO.getUnreadNotificationCountForUser(username);
-            String payload = String.format("{\"unreadCount\":%d}", unreadCount);
-            NotificationEventBroker.pushMessage(payload, Collections.singletonList(username));
-            return result;
         } catch (NotificationManagementDAOException e) {
             NotificationManagementDAOFactory.rollbackTransaction();
             String msg = "Error occurred while deleting notifications for user: " + username;
@@ -192,6 +199,13 @@ public class NotificationManagementServiceImpl implements NotificationManagement
         } finally {
             NotificationManagementDAOFactory.closeConnection();
         }
+        String payload = String.format("{\"unreadCount\":%d}", unreadCount);
+        try {
+            NotificationEventBroker.pushMessage(payload, Collections.singletonList(username));
+        } catch (Exception e) {
+            log.error("Error occurred while pushing unread notification count to user: " + username, e);
+        }
+        return result;
     }
 
     @Override
@@ -201,7 +215,6 @@ public class NotificationManagementServiceImpl implements NotificationManagement
             return Map.of("archived", Collections.emptyList(), "invalid", Collections.emptyList());
         }
         try {
-            username = NotificationHelper.getTenantAwareUsernameIfUserExists(username);
             NotificationArchivalDestDAOFactory.beginTransaction();
             NotificationArchivalSourceDAOFactory.beginTransaction();
             Map<String, List<Integer>> result =
@@ -221,13 +234,6 @@ public class NotificationManagementServiceImpl implements NotificationManagement
                 NotificationManagementDAOFactory.closeConnection();
             }
             return result;
-        } catch (NotificationManagementException e) {
-            NotificationArchivalDestDAOFactory.rollbackTransaction();
-            NotificationArchivalSourceDAOFactory.rollbackTransaction();
-            String msg = "Error occurred while archiving user notifications for user: " + username +
-                    "user doesn't exist";
-            log.error(msg, e);
-            throw new NotificationArchivalException(msg, e);
         } catch (TransactionManagementException e) {
             NotificationArchivalDestDAOFactory.rollbackTransaction();
             NotificationArchivalSourceDAOFactory.rollbackTransaction();
@@ -241,16 +247,15 @@ public class NotificationManagementServiceImpl implements NotificationManagement
     }
 
     @Override
-    public void deleteAllUserNotifications(String username) throws NotificationManagementException {
-        username = NotificationHelper.getTenantAwareUsernameIfUserExists(username);
+    public void deleteAllUserNotifications(String username, Boolean isRead) throws NotificationManagementException {
+        int unreadCount = 0;
         try {
             NotificationManagementDAOFactory.beginTransaction();
-            notificationDAO.deleteAllUserNotifications(username);
+            notificationDAO.deleteAllUserNotifications(username, isRead);
+            unreadCount = notificationDAO.getUnreadNotificationCountForUser(username);
             NotificationManagementDAOFactory.commitTransaction();
-            int unreadCount = notificationDAO.getUnreadNotificationCountForUser(username);
-            String payload = String.format("{\"unreadCount\":%d}", unreadCount);
-            NotificationEventBroker.pushMessage(payload, Collections.singletonList(username));
         } catch (NotificationManagementDAOException e) {
+            NotificationManagementDAOFactory.rollbackTransaction();
             String msg = "Error occurred while deleting all notifications.";
             log.error(msg, e);
             throw new NotificationManagementException(msg, e);
@@ -262,12 +267,17 @@ public class NotificationManagementServiceImpl implements NotificationManagement
         } finally {
             NotificationManagementDAOFactory.closeConnection();
         }
+        String payload = String.format("{\"unreadCount\":%d}", unreadCount);
+        try {
+            NotificationEventBroker.pushMessage(payload, Collections.singletonList(username));
+        } catch (Exception e) {
+            log.error("Error occurred while pushing unread notification count to user: " + username, e);
+        }
     }
 
     @Override
     public void archiveAllUserNotifications(String username) throws NotificationArchivalException {
         try {
-            username = NotificationHelper.getTenantAwareUsernameIfUserExists(username);
             NotificationArchivalDestDAOFactory.beginTransaction();
             NotificationArchivalSourceDAOFactory.beginTransaction();
             notificationArchiveDAO.archiveAllUserNotifications(username);
@@ -285,11 +295,6 @@ public class NotificationManagementServiceImpl implements NotificationManagement
             } finally {
                 NotificationManagementDAOFactory.closeConnection();
             }
-        } catch (NotificationManagementException e) {
-            String msg = "Error occurred while archiving user notifications for user: " + username +
-                    "user doesn't exist";
-            log.error(msg, e);
-            throw new NotificationArchivalException(msg, e);
         } catch (TransactionManagementException e) {
             String msg = "Error occurred while archiving all notifications for user: " + username;
             log.error(msg, e);

--- a/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.core/src/main/java/io/entgra/device/mgt/core/notification/mgt/core/util/NotificationHelper.java
+++ b/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.core/src/main/java/io/entgra/device/mgt/core/notification/mgt/core/util/NotificationHelper.java
@@ -262,6 +262,24 @@ public class NotificationHelper {
     }
 
     /**
+     * Gets the authenticated user from the Carbon context and returns the tenant-aware username.
+     * Validates that the user exists in the system.
+     *
+     * @return tenant-aware authenticated username
+     * @throws NotificationManagementException if the authenticated user is not found or does not exist
+     */
+    public static String getAuthenticatedUser() throws NotificationManagementException {
+        PrivilegedCarbonContext ctx = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+        String username = ctx.getUsername();
+        if (username == null || username.trim().isEmpty()) {
+            String msg = "Authenticated user not found in context.";
+            log.warn(msg);
+            throw new NotificationManagementException(msg);
+        }
+        return getTenantAwareUsernameIfUserExists(username);
+    }
+
+    /**
      * Validates that all users and roles in the recipients exist in the system.
      * Throws NotificationConfigurationServiceException if any user or role is invalid or does not exist.
      *


### PR DESCRIPTION
## Purpose
Several notification management APIs were relying on a username provided in the request body, which could lead to incorrect or insecure behavior if a client supplied a different user. Additionally, there was no API support to mark all notifications as READ or UNREAD in a single operation.

## Goals
- Ensure all notification read, archive, and delete operations are executed only for the authenticated user
- Prevent misuse of APIs by ignoring client-supplied usernames where authentication context is required
- Introduce an API to mark all notifications as READ or UNREAD for the logged-in user

## Approach

- Introduced a shared utility method to retrieve the authenticated username from the Carbon thread-local context
- **Updated existing notification APIs to:**
> - Replace request-provided usernames with the authenticated user
> - Maintain backward-compatible request payloads while enforcing server-side validation

- Added a new **PUT /action/all** API to update notification status (READ/UNREAD) in bulk
- Extended service, DAO, and implementation layers to support bulk updates
- Ensured unread notification counts are recalculated and pushed after bulk updates using the existing event broker mechanism