### PR TITLE
Set hostname header to GW for requests in tenant space

### DIFF
--- a/components/ui-request-interceptor/io.entgra.device.mgt.core.ui.request.interceptor/src/main/java/io/entgra/device/mgt/core/ui/request/interceptor/TenantInvokerHandler.java
+++ b/components/ui-request-interceptor/io.entgra.device.mgt.core.ui.request.interceptor/src/main/java/io/entgra/device/mgt/core/ui/request/interceptor/TenantInvokerHandler.java
@@ -323,6 +323,8 @@ public class TenantInvokerHandler extends HttpServlet {
             } else {
                 HandlerUtil.copyRequestHeaders(req, classicHttpRequest, false);
             }
+            classicHttpRequest.removeHeaders(HttpHeaders.HOST);
+            classicHttpRequest.setHeader(HttpHeaders.HOST, System.getProperty(HandlerConstants.IOT_GW_HOST_ENV_VAR));
 
             if (StringUtils.isNotBlank(tenantDomain)) {
                 classicHttpRequest.setHeader(HttpHeaders.AUTHORIZATION, HandlerConstants.BEARER +


### PR DESCRIPTION
## Purpose
Outgoing requests in tenant invoker handler inherits the original host header from the upstream context, which is the mgt host. This can lead to incorrect routing behavior when the requests are forwarded to the gateway.

This change explicitly sets the Host header to the configured Gateway host for requests in tenant space.