### PR TITLE
Synchronize application hash in metadata to prevent incorrect overwrites for Windows application artifacts

### DIFF
--- a/components/application-mgt/io.entgra.device.mgt.core.application.mgt.core/src/main/java/io/entgra/device/mgt/core/application/mgt/core/impl/ApplicationManagerImpl.java
+++ b/components/application-mgt/io.entgra.device.mgt.core.application.mgt.core/src/main/java/io/entgra/device/mgt/core/application/mgt/core/impl/ApplicationManagerImpl.java
@@ -18,6 +18,10 @@
 
 package io.entgra.device.mgt.core.application.mgt.core.impl;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 import io.entgra.device.mgt.core.application.mgt.common.ApplicationArtifact;
 import io.entgra.device.mgt.core.application.mgt.common.ApplicationInstaller;
 import io.entgra.device.mgt.core.application.mgt.common.ApplicationList;
@@ -82,6 +86,7 @@ import io.entgra.device.mgt.core.application.mgt.core.util.ApplicationManagement
 import io.entgra.device.mgt.core.application.mgt.core.util.ConnectionManagerUtil;
 import io.entgra.device.mgt.core.application.mgt.core.util.Constants;
 import io.entgra.device.mgt.core.device.mgt.common.Base64File;
+import io.entgra.device.mgt.core.device.mgt.common.MDMAppConstants;
 import io.entgra.device.mgt.core.device.mgt.common.PaginationRequest;
 import io.entgra.device.mgt.core.device.mgt.common.exceptions.DeviceManagementException;
 import io.entgra.device.mgt.core.device.mgt.common.exceptions.MetadataManagementException;
@@ -917,6 +922,10 @@ public class ApplicationManagerImpl implements ApplicationManager {
                     throw new BadRequestException(msg);
                 }
                 applicationReleaseDTO.setAppHashValue(md5OfApp);
+                if (DeviceTypes.WINDOWS.name().equalsIgnoreCase(deviceType) && applicationArtifact.getInstallerName()
+                        .toLowerCase().endsWith(Constants.EXTENSION_MSI)) {
+                    syncHashInMetadata(applicationReleaseDTO, md5OfApp);
+                }
                 applicationStorageManager
                         .uploadReleaseArtifact(applicationReleaseDTO, deviceType,
                                 Files.newInputStream(Paths.get(applicationArtifact.getInstallerPath())), tenantId);
@@ -1006,6 +1015,10 @@ public class ApplicationManagerImpl implements ApplicationManager {
                     applicationReleaseDTO.setPackageName(packageName);
                     String deletingAppHashValue = applicationReleaseDTO.getAppHashValue();
                     applicationReleaseDTO.setAppHashValue(md5OfApp);
+                    if (DeviceTypes.WINDOWS.name().equalsIgnoreCase(deviceType) && applicationArtifact.getInstallerName()
+                            .toLowerCase().endsWith(Constants.EXTENSION_MSI)) {
+                        syncHashInMetadata(applicationReleaseDTO, md5OfApp);
+                    }
                     applicationStorageManager.uploadReleaseArtifact(applicationReleaseDTO, deviceType,
                             Files.newInputStream(Paths.get(applicationArtifact.getInstallerPath())),
                             tenantId);
@@ -4534,4 +4547,52 @@ public class ApplicationManagerImpl implements ApplicationManager {
             ConnectionManagerUtil.closeDBConnection();
         }
     }
+
+    /**
+     * Synchronizes the backend calculated hash with the hash stored in the metadata JSON.
+     * @param releaseDTO The DTO containing existing metadata.
+     * @param md5OfApp The correct hash calculated by the backend.
+     * @throws ApplicationManagementException if metadata is malformed.
+     */
+    private void syncHashInMetadata(ApplicationReleaseDTO releaseDTO, String md5OfApp)
+            throws ApplicationManagementException {
+        String metaDataStr = releaseDTO.getMetaData();
+        if (StringUtils.isBlank(metaDataStr)) {
+            return;
+        }
+            try {
+                JsonArray metaDataArray = JsonParser.parseString(metaDataStr).getAsJsonArray();
+                String fileHashKey = MDMAppConstants.WindowsConstants.MSI_FILE_HASH;
+                int hashFoundIndex = -1;
+
+                for (int i = 0; i < metaDataArray.size(); i++) {
+                    JsonObject obj = metaDataArray.get(i).getAsJsonObject();
+
+                    if (obj.has("key") && fileHashKey.equals(obj.get("key").getAsString())) {
+                        hashFoundIndex = i;
+                        break;
+                    }
+                }
+                JsonObject hashObj = new JsonObject();
+                hashObj.addProperty("key", fileHashKey);
+                hashObj.addProperty("value", md5OfApp);
+
+                if (hashFoundIndex >= 0) {
+                    metaDataArray.set(hashFoundIndex, hashObj);
+                } else {
+                    metaDataArray.add(hashObj);
+                }
+
+                releaseDTO.setMetaData(metaDataArray.toString());
+            } catch (JsonSyntaxException e) {
+                String msg = "Invalid JSON format found in metadata while synchronizing File_Hash";
+                log.error(msg, e);
+                throw new ApplicationManagementException(msg, e);
+            } catch (IllegalStateException e) {
+                String msg = "Metadata JSON structure is invalid. Expected JSON array while synchronizing File_Hash";
+                log.error(msg, e);
+                throw new ApplicationManagementException(msg, e);
+            }
+        }
+
 }

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/util/MDMWindowsOperationUtil.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/util/MDMWindowsOperationUtil.java
@@ -197,7 +197,12 @@ public class MDMWindowsOperationUtil {
                     hostedMSIApplication.setProductId(metaObject.get("value").getAsString().trim());
                 }
                 else if (MDMAppConstants.WindowsConstants.MSI_FILE_HASH.equals(metaObject.get("key").getAsString())) {
-                    hostedMSIApplication.setFileHash(metaObject.get("value").getAsString().trim());
+                    if (metaObject.has("value") && !metaObject.get("value").isJsonNull()) {
+                        hostedMSIApplication.setFileHash(metaObject.get("value").getAsString().trim());
+                    }
+                    else {
+                        log.warn("MSI File_Hash is null or missing in metadata for app payload creation.");
+                    }
                 }
             }
             enterpriseApplication.setHostedMSIApplication(hostedMSIApplication);

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/util/MDMWindowsOperationUtil.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/util/MDMWindowsOperationUtil.java
@@ -197,8 +197,16 @@ public class MDMWindowsOperationUtil {
                     hostedMSIApplication.setProductId(metaObject.get("value").getAsString().trim());
                 }
                 else if (MDMAppConstants.WindowsConstants.MSI_FILE_HASH.equals(metaObject.get("key").getAsString())) {
-                    hostedMSIApplication.setFileHash(metaObject.get("value").getAsString().trim());
+                    if (metaObject.has("value") && !metaObject.get("value").isJsonNull()) {
+                        hostedMSIApplication.setFileHash(metaObject.get("value").getAsString().trim());
+                    }
                 }
+            }
+
+            if (hostedMSIApplication.getFileHash() == null || hostedMSIApplication.getFileHash().trim().isEmpty()) {
+                String msg = "Failed to create MSI application payload: required metadata field File_Hash is missing.";
+                log.error(msg);
+                throw new IllegalArgumentException(msg);
             }
             enterpriseApplication.setHostedMSIApplication(hostedMSIApplication);
         } else if (MDMAppConstants.WindowsConstants.EXE.equalsIgnoreCase(appType)) {


### PR DESCRIPTION
**Purpose**
Fixes: https://roadmap.entgra.net/issues/15952

**Description**

- Synchronized File_Hash in metadata with the backend calculated application MD5 hash.
- Prevented incorrect hash overwrites caused by image, icon or screenshot artifact uploads.
- Ensured the hash is always derived from the application artifact.
- Updated existing File_Hash entry in metadata if present.
- Added File_Hash entry if it does not exist in metadata.