### PR TITLE
Fix DB connection pool exhaustion caused by connection leak

### DIFF
--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/archival/dao/ArchivalDestinationDAOFactory.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/archival/dao/ArchivalDestinationDAOFactory.java
@@ -66,8 +66,14 @@ public class ArchivalDestinationDAOFactory {
     }
 
     public static void beginTransaction() throws TransactionManagementException {
+        Connection conn = currentConnection.get();
+        if (conn != null) {
+            throw new IllegalTransactionStateException("A transaction is already active within the context of " +
+                    "this particular thread. Therefore, calling 'beginTransaction/openConnection' while another " +
+                    "transaction is already active is a sign of improper transaction handling");
+        }
         try {
-            Connection conn = dataSource.getConnection();
+            conn = dataSource.getConnection();
             conn.setAutoCommit(false);
             currentConnection.set(conn);
         } catch (SQLException e) {
@@ -87,7 +93,14 @@ public class ArchivalDestinationDAOFactory {
     }
 
     public static void openConnection() throws SQLException {
-        currentConnection.set(dataSource.getConnection());
+        Connection conn = currentConnection.get();
+        if (conn != null) {
+            throw new IllegalTransactionStateException("A transaction is already active within the context of " +
+                    "this particular thread. Therefore, calling 'beginTransaction/openConnection' while another " +
+                    "transaction is already active is a sign of improper transaction handling");
+        }
+        conn = dataSource.getConnection();
+        currentConnection.set(conn);
     }
 
     public static Connection getConnection() throws SQLException {

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/archival/dao/ArchivalSourceDAOFactory.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/archival/dao/ArchivalSourceDAOFactory.java
@@ -69,8 +69,14 @@ public class ArchivalSourceDAOFactory {
     }
 
     public static void beginTransaction() throws TransactionManagementException {
+        Connection conn = currentConnection.get();
+        if (conn != null) {
+            throw new IllegalTransactionStateException("A transaction is already active within the context of " +
+                    "this particular thread. Therefore, calling 'beginTransaction/openConnection' while another " +
+                    "transaction is already active is a sign of improper transaction handling");
+        }
         try {
-            Connection conn = dataSource.getConnection();
+            conn = dataSource.getConnection();
             conn.setAutoCommit(false);
             currentConnection.set(conn);
         } catch (SQLException e) {
@@ -80,7 +86,14 @@ public class ArchivalSourceDAOFactory {
     }
 
     public static void openConnection() throws SQLException {
-        currentConnection.set(dataSource.getConnection());
+        Connection conn = currentConnection.get();
+        if (conn != null) {
+            throw new IllegalTransactionStateException("A transaction is already active within the context of " +
+                    "this particular thread. Therefore, calling 'beginTransaction/openConnection' while another " +
+                    "transaction is already active is a sign of improper transaction handling");
+        }
+        conn = dataSource.getConnection();
+        currentConnection.set(conn);
     }
 
     public static Connection getConnection() throws SQLException {

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/mgt/OperationManagerImpl.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/mgt/OperationManagerImpl.java
@@ -927,7 +927,6 @@ public class OperationManagerImpl implements OperationManager {
                                         Operation.Status.valueOf(operation.getStatus().toString()));
                         OperationManagementDAOFactory.commitTransaction();
                         try {
-                            OperationManagementDAOFactory.openConnection();
                             DeviceOperationDetails previousDeviceOperationDetails =
                                     operationDAO.getDeviceOperationDetails(enrolmentId, operationId);
                             if (isOperationUpdated && previousDeviceOperationDetails != null) {

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/mgt/dao/OperationManagementDAOFactory.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/mgt/dao/OperationManagementDAOFactory.java
@@ -119,8 +119,14 @@ public class OperationManagementDAOFactory {
     }
 
     public static void beginTransaction() throws TransactionManagementException {
+        Connection conn = currentConnection.get();
+        if (conn != null) {
+            throw new IllegalTransactionStateException("A transaction is already active within the context of " +
+                    "this particular thread. Therefore, calling 'beginTransaction/openConnection' while another " +
+                    "transaction is already active is a sign of improper transaction handling");
+        }
         try {
-            Connection conn = dataSource.getConnection();
+            conn = dataSource.getConnection();
             conn.setAutoCommit(false);
             currentConnection.set(conn);
         } catch (SQLException e) {
@@ -130,7 +136,14 @@ public class OperationManagementDAOFactory {
     }
 
     public static void openConnection() throws SQLException {
-        currentConnection.set(dataSource.getConnection());
+        Connection conn = currentConnection.get();
+        if (conn != null) {
+            throw new IllegalTransactionStateException("A transaction is already active within the context of " +
+                    "this particular thread. Therefore, calling 'beginTransaction/openConnection' while another " +
+                    "transaction is already active is a sign of improper transaction handling");
+        }
+        conn = dataSource.getConnection();
+        currentConnection.set(conn);
     }
 
     public static Connection getConnection() throws SQLException {

--- a/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.core/src/main/java/io/entgra/device/mgt/core/notification/mgt/core/dao/factory/archive/NotificationArchivalDestDAOFactory.java
+++ b/components/notification-mgt/io.entgra.device.mgt.core.notification.mgt.core/src/main/java/io/entgra/device/mgt/core/notification/mgt/core/dao/factory/archive/NotificationArchivalDestDAOFactory.java
@@ -121,8 +121,14 @@ public class NotificationArchivalDestDAOFactory {
     }
 
     public static void beginTransaction() throws TransactionManagementException {
+        Connection conn = currentConnection.get();
+        if (conn != null) {
+            throw new IllegalTransactionStateException("A transaction is already active within the context of " +
+                    "this particular thread. Therefore, calling 'beginTransaction/openConnection' while another " +
+                    "transaction is already active is a sign of improper transaction handling");
+        }
         try {
-            Connection conn = dataSource.getConnection();
+            conn = dataSource.getConnection();
             conn.setAutoCommit(false);
             currentConnection.set(conn);
         } catch (SQLException e) {
@@ -131,7 +137,14 @@ public class NotificationArchivalDestDAOFactory {
     }
 
     public static void openConnection() throws SQLException {
-        currentConnection.set(dataSource.getConnection());
+        Connection conn = currentConnection.get();
+        if (conn != null) {
+            throw new IllegalTransactionStateException("A transaction is already active within the context of " +
+                    "this particular thread. Therefore, calling 'beginTransaction/openConnection' while another " +
+                    "transaction is already active is a sign of improper transaction handling");
+        }
+        conn = dataSource.getConnection();
+        currentConnection.set(conn);
     }
 
     public static Connection getConnection() {


### PR DESCRIPTION
## Purpose
Under concurrent device sync load, the database connection pool was being fully 
exhausted, causing `PoolExhaustedException` errors 
and cascading failures across the device management platform, most visibly on the 
`pending-operations` endpoint used by devices during sync.

## Goals
- Fix the connection leak in `OperationManagerImpl.updateOperation()` that was 
  exhausting the database connection pool under load
- Prevent silent connection leaks of the same nature from occurring in the future 
  by adding a defensive guard to `OperationManagementDAOFactory` and others.

## Approach

**Fix 1 - Remove the redundant openConnection() call:**  
Removed the erroneous `openConnection()` call inside the already active transaction 
block. The `getDeviceOperationDetails()` call now reuses the existing transaction 
connection that remains in the threadLocal after `commitTransaction()`, as intended.

**Fix 2  Add active connection guard :**  
Added a null check to both `openConnection()` and `beginTransaction()` to throw 
`IllegalTransactionStateException` if a connection is already active on the current 
thread, rather than silently replacing and abandoning it.

## Related Issue Ticket
https://roadmap.entgra.net/issues/16145