### PR TITLE
Fix timeout query to reference created timestamp

### DIFF
--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/mgt/dao/impl/GenericOperationDAOImpl.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/mgt/dao/impl/GenericOperationDAOImpl.java
@@ -2300,14 +2300,14 @@ public class GenericOperationDAOImpl implements OperationDAO {
             }
 
             if (updatedSince != 0) {
-                sql.append("AND UPDATED_TIMESTAMP < ? ");
+                sql.append("AND CREATED_TIMESTAMP < ? ");
             }
 
             if (operationStatus != null) {
                 sql.append("AND STATUS = ? ");
             }
 
-            sql.append("ORDER BY OPERATION_ID, UPDATED_TIMESTAMP");
+            sql.append("ORDER BY OPERATION_ID, CREATED_TIMESTAMP");
 
             int index = 1;
             try (PreparedStatement stmt = conn.prepareStatement(sql.toString())) {


### PR DESCRIPTION
## Purpose
> The getTimeoutActivity function was incorrectly referencing the updated_timestamp timestamp, causing issues with task timeout validation.

## Goals
> - **Updated:** `getTimeoutActivities` query.
> - **Reason:** Using `updated_timestamp` caused tasks to expire more than the expected time if they were modified frequently.
> - **Fix:** Timeout calculation now relies on the immutable `CREATED_TIMESTAMP`.

## Approach
> Modified the getTimeoutActivities function to query against the CREATED_TIMESTAMP column instead of the updated timestamp.