### PR TITLE
fix: convert milliseconds to seconds before comparing CREATED_TIMESTAMP in DB query

### DIFF
--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/mgt/dao/impl/GenericOperationDAOImpl.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/mgt/dao/impl/GenericOperationDAOImpl.java
@@ -2300,14 +2300,14 @@ public class GenericOperationDAOImpl implements OperationDAO {
             }
 
             if (updatedSince != 0) {
-                sql.append("AND UPDATED_TIMESTAMP < ? ");
+                sql.append("AND CREATED_TIMESTAMP < ? ");
             }
 
             if (operationStatus != null) {
                 sql.append("AND STATUS = ? ");
             }
 
-            sql.append("ORDER BY OPERATION_ID, UPDATED_TIMESTAMP");
+            sql.append("ORDER BY OPERATION_ID, CREATED_TIMESTAMP");
 
             int index = 1;
             try (PreparedStatement stmt = conn.prepareStatement(sql.toString())) {

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/timeout/task/impl/OperationTimeoutTask.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/timeout/task/impl/OperationTimeoutTask.java
@@ -88,7 +88,7 @@ public class OperationTimeoutTask extends RandomlyAssignedScheduleTask {
         Gson gson = new Gson();
         OperationTimeout operationTimeoutConfig = gson.fromJson(operationTimeoutTaskConfigStr, OperationTimeout.class);
         try {
-            long timeMillis = System.currentTimeMillis() - (long) operationTimeoutConfig.getTimeout();
+            long timeMillis = (System.currentTimeMillis() - (long) operationTimeoutConfig.getTimeout()) / 1000L;
 
             List<String> deviceTypes = getDeviceTypes(operationTimeoutConfig);
 

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/timeout/task/impl/OperationTimeoutTask.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/timeout/task/impl/OperationTimeoutTask.java
@@ -88,12 +88,12 @@ public class OperationTimeoutTask extends RandomlyAssignedScheduleTask {
         Gson gson = new Gson();
         OperationTimeout operationTimeoutConfig = gson.fromJson(operationTimeoutTaskConfigStr, OperationTimeout.class);
         try {
-            long timeMillis = (System.currentTimeMillis() - (long) operationTimeoutConfig.getTimeout()) / 1000L;
+            long thresholdSeconds = (System.currentTimeMillis() - (long) operationTimeoutConfig.getTimeout()) / 1000L;
 
             List<String> deviceTypes = getDeviceTypes(operationTimeoutConfig);
 
             List<Activity> activities = DeviceManagementDataHolder.getInstance().getOperationManager()
-                    .getTimeoutActivities(deviceTypes, operationTimeoutConfig.getCode(), timeMillis,
+                    .getTimeoutActivities(deviceTypes, operationTimeoutConfig.getCode(), thresholdSeconds,
                             operationTimeoutConfig.getInitialStatus());
 
             if (activities == null || activities.isEmpty()) {


### PR DESCRIPTION
## Purpose
The operation timeout filter in the DB query was not functioning correctly due to a unit mismatch. `System.currentTimeMillis()` returns time in milliseconds, but the `CREATED_TIMESTAMP` column is stored as Unix time in seconds in a MySQL `INT` column. Passing the raw millisecond value (13 digits) to the query caused a silent integer overflow, which effectively made the condition `AND CREATED_TIMESTAMP < ?` always true — meaning the timeout filter was a no-op and all records were being fetched regardless of their age.

## Goals
- Ensure the `AND CREATED_TIMESTAMP < ?` filter correctly excludes records that have not yet exceeded the operation timeout
- Prevent unnecessary records from being fetched from the DB and filtered in application memory
- Improve code clarity around time unit usage

## Approach
- Divide the computed threshold value by `1000L` to convert milliseconds to seconds before binding it to the query
- Rename the variable from `timeMillis` to `thresholdSeconds` to accurately reflect the unit and avoid confusion for future developers

Before:
```java
long timeMillis = System.currentTimeMillis() - (long) operationTimeoutConfig.getTimeout();
```
After:
```java
long thresholdSeconds = (System.currentTimeMillis() - (long) operationTimeoutConfig.getTimeout()) / 1000L;
```