### PR TITLE
feat(ops): add skip notification option for operations

### DIFF
--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/mgt/OperationManagerImpl.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/operation/mgt/OperationManagerImpl.java
@@ -96,6 +96,7 @@ import java.util.concurrent.ThreadPoolExecutor;
  */
 public class OperationManagerImpl implements OperationManager {
 
+    private static final String SKIP_IMMEDIATE_NOTIFICATION_PROPERTY = "skip-immediate-notification";
     DeviceConnectivityLogContext.Builder deviceConnectivityLogContextBuilder = new DeviceConnectivityLogContext.Builder();
     private static final EntgraLogger log = new EntgraDeviceConnectivityLoggerImpl(OperationManagerImpl.class);
     private static final int CACHE_VALIDITY_PERIOD = 5 * 60 * 1000;
@@ -228,7 +229,9 @@ public class OperationManagerImpl implements OperationManager {
                     for (Integer enrolmentId : pendingOperationIDs.keySet()) {
                         operation.setId(pendingOperationIDs.get(enrolmentId));
                         device = enrolments.get(enrolmentId);
-                        this.sendNotification(operation, device);
+                        if (!shouldSkipImmediateNotification(operation)) {
+                            this.sendNotification(operation, device);
+                        }
                         //No need to keep this enrollment as it has a pending operation
                         enrolments.remove(enrolmentId);
                     }
@@ -301,7 +304,9 @@ public class OperationManagerImpl implements OperationManager {
                 for (Integer enrolmentId : pendingOperationIDs.keySet()) {
                     operation.setId(pendingOperationIDs.get(enrolmentId));
                     device = enrolments.get(enrolmentId);
-                    this.sendNotification(operation, device);
+                    if (!shouldSkipImmediateNotification(operation)) {
+                        this.sendNotification(operation, device);
+                    }
                     //No need to keep this enrollment as it has a pending operation
                     enrolments.remove(enrolmentId);
                 }
@@ -375,7 +380,9 @@ public class OperationManagerImpl implements OperationManager {
                     for (Integer enrolmentId : pendingOperationIDs.keySet()) {
                         operation.setId(pendingOperationIDs.get(enrolmentId));
                         device = enrolments.get(enrolmentId);
-                        this.sendNotification(operation, device);
+                        if (!shouldSkipImmediateNotification(operation)) {
+                            this.sendNotification(operation, device);
+                        }
                         //No need to keep this enrollment as it has a pending operation
                         enrolments.remove(enrolmentId);
                     }
@@ -463,11 +470,25 @@ public class OperationManagerImpl implements OperationManager {
             String msg = "An Error occurred while updating handleOperationNotificationIfApplicable";
             log.error(msg, e);
         }
-        if (!isScheduled && notificationStrategy != null) {
+        if (!isScheduled && notificationStrategy != null && !shouldSkipImmediateNotification(operation)) {
             for (Device device : enrolments.values()) {
                 this.sendNotification(operation, device);
             }
         }
+    }
+
+    /**
+     * Checks if the given operation is configured to skip immediate notifications.
+     *
+     * @param operation the operation to check
+     * @return true if the skip property is set to "true", false otherwise
+     */
+    private boolean shouldSkipImmediateNotification(Operation operation) {
+        if (operation == null || operation.getProperties() == null) {
+            return false;
+        }
+        return Boolean.parseBoolean(
+                operation.getProperties().getProperty(SKIP_IMMEDIATE_NOTIFICATION_PROPERTY, Boolean.FALSE.toString()));
     }
 
     private void sendNotification(Operation operation, Device device) {


### PR DESCRIPTION
Ticket : https://roadmap.entgra.net/issues/14805

Summary

  This change adds support for skipping immediate push notifications when
  creating operations by introducing the skip-immediate-notification operation
  property.

  When this property is set to true, the operation is still persisted and mapped
  to devices as usual, but the system avoids triggering immediate notifications
  for:

  - newly added operations
  - existing pending NO_REPEAT operations
  - task-based and bulk operation flows

  Why

  Some operation flows need to queue or persist operations without notifying
  devices right away. This update makes that behavior explicit and controllable
  through an operation property, without changing the default notification
  behavior for existing callers.

  Changes

  - Added skip-immediate-notification as an operation property checked inside
    OperationManagerImpl
  - Prevented immediate notification dispatch when the property is enabled
  - Applied the same check consistently across standard operation creation, task
    operations, and repeated pending operation handling
  - Kept the default behavior unchanged when the property is absent or set to
    false