### PR TITLE
Add per tenant metadata saving, updating and deleting

### DIFF
--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/metadata/mgt/MetadataManagementServiceImpl.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/metadata/mgt/MetadataManagementServiceImpl.java
@@ -20,6 +20,7 @@ package io.entgra.device.mgt.core.device.mgt.core.metadata.mgt;
 
 import io.entgra.device.mgt.core.device.mgt.common.PaginationRequest;
 import io.entgra.device.mgt.core.device.mgt.common.PaginationResult;
+import io.entgra.device.mgt.core.device.mgt.common.exceptions.DeviceManagementException;
 import io.entgra.device.mgt.core.device.mgt.common.exceptions.MetadataKeyAlreadyExistsException;
 import io.entgra.device.mgt.core.device.mgt.common.exceptions.MetadataKeyNotFoundException;
 import io.entgra.device.mgt.core.device.mgt.common.exceptions.MetadataManagementException;
@@ -57,11 +58,17 @@ public class MetadataManagementServiceImpl implements MetadataManagementService 
         if (log.isDebugEnabled()) {
             log.debug("Creating Metadata : [" + metadata.toString() + "]");
         }
+
+        if (isPerTenantMetaKey(metadata.getMetaKey())) {
+            String tenantDomain = extractTenantDomain(metadata.getMetaKey());
+            return createMetadataForTenant(metadata, tenantDomain);
+        }
+
         int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId(true);
         try {
             MetadataManagementDAOFactory.beginTransaction();
             if (metadataDAO.isExist(tenantId, metadata.getMetaKey())) {
-                String msg = "Specified metaKey is already exist. {metaKey:" + metadata.getMetaKey() + "}";
+                String msg = "Specified metaKey already exists. {metaKey:" + metadata.getMetaKey() + "}";
                 log.error(msg);
                 throw new MetadataKeyAlreadyExistsException(msg);
             }
@@ -71,6 +78,10 @@ public class MetadataManagementServiceImpl implements MetadataManagementService 
                 log.debug("Metadata entry created successfully. " + metadata.toString());
             }
             return metadata;
+        } catch (MetadataKeyAlreadyExistsException e) {
+            MetadataManagementDAOFactory.rollbackTransaction();
+            String msg = "Meta Key already exists.";
+            throw new MetadataManagementException(msg, e);
         } catch (MetadataManagementDAOException e) {
             MetadataManagementDAOFactory.rollbackTransaction();
             String msg = "Error occurred while creating the metadata entry. " + metadata.toString();
@@ -79,9 +90,71 @@ public class MetadataManagementServiceImpl implements MetadataManagementService 
         } catch (TransactionManagementException e) {
             String msg = "Error occurred while opening a connection to the data source";
             log.error(msg, e);
-            throw new MetadataManagementException("Error occurred while creating metadata record", e);
+            throw new MetadataManagementException(msg, e);
         } finally {
             MetadataManagementDAOFactory.closeConnection();
+        }
+    }
+
+    /**
+     * Creates a metadata entry under the specified tenant's context rather than the currently
+     * active (carbon.super) tenant. This is used when configuring per-tenant settings such as
+     * per-device cost from the super tenant's admin console, ensuring the metadata is stored
+     * against the correct target tenant's ID.
+     *
+     * @param metadata     the {@link Metadata} object to be created, containing the metaKey and metaValue
+     * @param tenantDomain the domain of the target tenant under which the metadata should be stored
+     * @return the created {@link Metadata} object
+     * @throws MetadataManagementException       if an error occurs while resolving the tenant ID,
+     *                                           opening a data source connection, or persisting the entry
+     * @throws MetadataKeyAlreadyExistsException if a metadata entry with the same metaKey already
+     *                                           exists under the target tenant
+     */
+    private Metadata createMetadataForTenant(Metadata metadata, String tenantDomain)
+            throws MetadataManagementException, MetadataKeyAlreadyExistsException {
+        int targetTenantId;
+        try {
+            targetTenantId = DeviceManagerUtil.getTenantId(tenantDomain);
+        } catch (DeviceManagementException e) {
+            String msg = "Error occurred while resolving tenant ID for domain: " + tenantDomain;
+            log.error(msg, e);
+            throw new MetadataManagementException(msg, e);
+        }
+
+        try {
+            PrivilegedCarbonContext.startTenantFlow();
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(targetTenantId, true);
+
+            MetadataManagementDAOFactory.beginTransaction();
+            if (metadataDAO.isExist(targetTenantId, metadata.getMetaKey())) {
+                String msg = "Specified metaKey already exists for tenant: " + tenantDomain +
+                        " {metaKey:" + metadata.getMetaKey() + "}";
+                log.error(msg);
+                throw new MetadataKeyAlreadyExistsException(msg);
+            }
+            metadataDAO.addMetadata(targetTenantId, metadata);
+            MetadataManagementDAOFactory.commitTransaction();
+            if (log.isDebugEnabled()) {
+                log.debug("Per-tenant metadata created successfully for tenant: " + tenantDomain +
+                        " " + metadata.toString());
+            }
+            return metadata;
+        } catch (MetadataKeyAlreadyExistsException e) {
+            MetadataManagementDAOFactory.rollbackTransaction();
+            String msg = "Meta Key already exists.";
+            throw new MetadataManagementException(msg, e);
+        } catch (MetadataManagementDAOException e) {
+            MetadataManagementDAOFactory.rollbackTransaction();
+            String msg = "Error occurred while creating per-tenant metadata entry. " + metadata.toString();
+            log.error(msg, e);
+            throw new MetadataManagementException(msg, e);
+        } catch (TransactionManagementException e) {
+            String msg = "Error occurred while opening a connection to the data source";
+            log.error(msg, e);
+            throw new MetadataManagementException(msg, e);
+        } finally {
+            MetadataManagementDAOFactory.closeConnection();
+            PrivilegedCarbonContext.endTenantFlow();
         }
     }
 
@@ -93,11 +166,11 @@ public class MetadataManagementServiceImpl implements MetadataManagementService 
         try {
             MetadataManagementDAOFactory.openConnection();
             int tenantId;
-            if (metaKey.equals("EVALUATE_TENANTS") || metaKey.equals("PER_DEVICE_COST")){
+            if (metaKey.equals("EVALUATE_TENANTS")) {
                 // for getting per device cost and evaluate tenant list to provide the billing feature and live chat feature
-                 tenantId = MultitenantConstants.SUPER_TENANT_ID;
+                tenantId = MultitenantConstants.SUPER_TENANT_ID;
             } else {
-                 tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId(true);
+                tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId(true);
             }
             return metadataDAO.getMetadata(tenantId, metaKey);
         } catch (MetadataManagementDAOException e) {
@@ -172,20 +245,19 @@ public class MetadataManagementServiceImpl implements MetadataManagementService 
         if (log.isDebugEnabled()) {
             log.debug("Updating Metadata : [" + metadata.toString() + "]");
         }
+
+        if (isPerTenantMetaKey(metadata.getMetaKey())) {
+            String tenantDomain = extractTenantDomain(metadata.getMetaKey());
+            return updateMetadataForTenant(metadata, tenantDomain);
+        }
+
         int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId(true);
         try {
             MetadataManagementDAOFactory.beginTransaction();
             if (metadataDAO.isExist(tenantId, metadata.getMetaKey())) {
                 metadataDAO.updateMetadata(tenantId, metadata);
-                if (log.isDebugEnabled()) {
-                    log.debug("A Metadata entry has updated successfully. " + metadata.toString());
-                }
             } else {
                 metadataDAO.addMetadata(tenantId, metadata);
-                if (log.isDebugEnabled()) {
-                    log.debug("Metadata entry has inserted successfully, due to the absence of provided metaKey " +
-                            metadata.toString());
-                }
             }
             MetadataManagementDAOFactory.commitTransaction();
             return metadata;
@@ -203,23 +275,90 @@ public class MetadataManagementServiceImpl implements MetadataManagementService 
         }
     }
 
+    /**
+     * Updates or inserts a metadata entry under the specified tenant's context rather than the
+     * currently active (carbon.super) tenant. This is used when configuring per-tenant settings
+     * such as per-device cost from the super tenant's admin console, ensuring the metadata is
+     * stored against the correct target tenant's ID.
+     *
+     * <p>If a metadata entry with the given metaKey already exists under the target tenant,
+     * it will be updated. Otherwise, a new entry will be inserted.</p>
+     *
+     * @param metadata     the {@link Metadata} object to be updated or inserted,
+     *                     containing the metaKey and metaValue
+     * @param tenantDomain the domain of the target tenant under which the metadata should be stored
+     * @return the updated or inserted {@link Metadata} object
+     * @throws MetadataManagementException if an error occurs while resolving the tenant ID,
+     *                                     opening a data source connection, or persisting the entry
+     */
+    private Metadata updateMetadataForTenant(Metadata metadata, String tenantDomain)
+            throws MetadataManagementException {
+        int targetTenantId;
+        try {
+            targetTenantId = DeviceManagerUtil.getTenantId(tenantDomain);
+        } catch (DeviceManagementException e) {
+            String msg = "Error occurred while resolving tenant ID for domain: " + tenantDomain;
+            log.error(msg, e);
+            throw new MetadataManagementException(msg, e);
+        }
+
+        try {
+            PrivilegedCarbonContext.startTenantFlow();
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(targetTenantId, true);
+
+            MetadataManagementDAOFactory.beginTransaction();
+            if (metadataDAO.isExist(targetTenantId, metadata.getMetaKey())) {
+                metadataDAO.updateMetadata(targetTenantId, metadata);
+                if (log.isDebugEnabled()) {
+                    log.debug("Per-tenant metadata updated for tenant: " + tenantDomain);
+                }
+            } else {
+                metadataDAO.addMetadata(targetTenantId, metadata);
+                if (log.isDebugEnabled()) {
+                    log.debug("Per-tenant metadata created for tenant: " + tenantDomain);
+                }
+            }
+            MetadataManagementDAOFactory.commitTransaction();
+            return metadata;
+        } catch (MetadataManagementDAOException e) {
+            MetadataManagementDAOFactory.rollbackTransaction();
+            String msg = "Error occurred while updating per-tenant metadata entry. " + metadata.toString();
+            log.error(msg, e);
+            throw new MetadataManagementException(msg, e);
+        } catch (TransactionManagementException e) {
+            String msg = "Error occurred while opening a connection to the data source";
+            log.error(msg, e);
+            throw new MetadataManagementException(msg, e);
+        } finally {
+            MetadataManagementDAOFactory.closeConnection();
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+    }
+
     @Override
     public boolean deleteMetadata(String key) throws MetadataManagementException, MetadataKeyNotFoundException {
         if (log.isDebugEnabled()) {
             log.debug("Deleting metadata entry. {metaKey:" + key + "}");
         }
+
+        if (isPerTenantMetaKey(key)) {
+            String tenantDomain = extractTenantDomain(key);
+            return deleteMetadataForTenant(key, tenantDomain);
+        }
+
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId(true);
         try {
             MetadataManagementDAOFactory.beginTransaction();
-            boolean status = metadataDAO.deleteMetadata(
-                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId(true), key);
-            MetadataManagementDAOFactory.commitTransaction();
+            boolean status = metadataDAO.deleteMetadata(tenantId, key);
             if (status) {
+                MetadataManagementDAOFactory.commitTransaction();
                 if (log.isDebugEnabled()) {
-                    log.debug("Metadata entry has deleted successfully. {metaKey:" + key + "}");
+                    log.debug("Metadata entry deleted successfully. {metaKey:" + key + "}");
                 }
                 return true;
             } else {
-                String msg = "Specified Metadata entry has not found. {metaKey:" + key + "}";
+                MetadataManagementDAOFactory.rollbackTransaction();
+                String msg = "Specified Metadata entry not found. {metaKey:" + key + "}";
                 log.error(msg);
                 throw new MetadataKeyNotFoundException(msg);
             }
@@ -234,6 +373,67 @@ public class MetadataManagementServiceImpl implements MetadataManagementService 
             throw new MetadataManagementException(msg, e);
         } finally {
             MetadataManagementDAOFactory.closeConnection();
+        }
+    }
+
+    /**
+     * Deletes a metadata entry under the specified tenant's context rather than the currently
+     * active (carbon.super) tenant. This is used when removing per-tenant configuration keys
+     * such as per-device cost, DFRM enablement, and permission config, which are managed from
+     * the super tenant's admin console but stored under the respective target tenant's context.
+     *
+     * @param key          the metadata key to be deleted
+     * @param tenantDomain the domain of the target tenant under which the metadata is stored
+     * @return {@code true} if the metadata entry was successfully deleted
+     * @throws MetadataManagementException  if an error occurs while resolving the tenant ID,
+     *                                      opening a data source connection, or deleting the entry
+     * @throws MetadataKeyNotFoundException if no metadata entry exists for the given key
+     *                                      under the target tenant
+     */
+    private boolean deleteMetadataForTenant(String key, String tenantDomain)
+            throws MetadataManagementException, MetadataKeyNotFoundException {
+        int targetTenantId;
+        try {
+            targetTenantId = DeviceManagerUtil.getTenantId(tenantDomain);
+        } catch (DeviceManagementException e) {
+            String msg = "Error occurred while resolving tenant ID for domain: " + tenantDomain;
+            log.error(msg, e);
+            throw new MetadataManagementException(msg, e);
+        }
+
+        try {
+            PrivilegedCarbonContext.startTenantFlow();
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(targetTenantId, true);
+
+            MetadataManagementDAOFactory.beginTransaction();
+            boolean status = metadataDAO.deleteMetadata(targetTenantId, key);
+            if (status) {
+                MetadataManagementDAOFactory.commitTransaction();
+                if (log.isDebugEnabled()) {
+                    log.debug("Per-tenant metadata deleted successfully for tenant: " + tenantDomain +
+                            " {metaKey:" + key + "}");
+                }
+                return true;
+            } else {
+                MetadataManagementDAOFactory.rollbackTransaction();
+                String msg = "Specified per-tenant metadata entry not found for tenant: " + tenantDomain +
+                        " {metaKey:" + key + "}";
+                log.error(msg);
+                throw new MetadataKeyNotFoundException(msg);
+            }
+        } catch (MetadataManagementDAOException e) {
+            MetadataManagementDAOFactory.rollbackTransaction();
+            String msg = "Error occurred while deleting per-tenant metadata entry for tenant: " +
+                    tenantDomain + " {metaKey:" + key + "}";
+            log.error(msg, e);
+            throw new MetadataManagementException(msg, e);
+        } catch (TransactionManagementException e) {
+            String msg = "Error occurred while opening a connection to the data source";
+            log.error(msg, e);
+            throw new MetadataManagementException(msg, e);
+        } finally {
+            MetadataManagementDAOFactory.closeConnection();
+            PrivilegedCarbonContext.endTenantFlow();
         }
     }
 
@@ -269,6 +469,41 @@ public class MetadataManagementServiceImpl implements MetadataManagementService 
         } finally {
             MetadataManagementDAOFactory.closeConnection();
         }
+    }
+
+    /**
+     * Determines whether the given metaKey requires tenant-scoped storage under a specific
+     * target tenant rather than the currently active tenant. This applies to per-tenant
+     * configuration keys such as per-device cost, DFRM enablement, and permission config,
+     * which are managed from the carbon.super admin console but must be stored under the
+     * respective target tenant's context.
+     *
+     * @param metaKey the metadata key to evaluate
+     * @return {@code true} if the metaKey requires tenant-scoped storage, {@code false} otherwise
+     */
+    private boolean isPerTenantMetaKey(String metaKey) {
+        return metaKey.endsWith("_PER_DEVICE_COST")
+                || metaKey.contains("_dfrm_enabled_tenant")
+                || metaKey.contains("_permission_config");
+    }
+
+    /**
+     * Extracts the target tenant domain from a per-tenant metaKey by stripping the
+     * known per-tenant key suffixes. The tenant domain is expected to be the prefix
+     * portion of the metaKey before the suffix delimiter.
+     *
+     * @param metaKey the per-tenant metadata key from which to extract the tenant domain
+     * @return the tenant domain extracted from the metaKey
+     */
+    private String extractTenantDomain(String metaKey) {
+        if (metaKey.endsWith("_PER_DEVICE_COST")) {
+            return metaKey.replace("_PER_DEVICE_COST", "");
+        } else if (metaKey.contains("_dfrm_enabled_tenant")) {
+            return metaKey.replace("_dfrm_enabled_tenant", "");
+        } else if (metaKey.contains("_permission_config")) {
+            return metaKey.replace("_permission_config", "");
+        }
+        return metaKey;
     }
 
 }


### PR DESCRIPTION
## Purpose
Per-tenant metadata keys such as `<tenantDomain>_PER_DEVICE_COST`, `<tenantDomain>_dfrm_enabled_tenant`, and `<tenantDomain>_permission_config` are configured from the carbon.super admin console. However, the `createMetadata`, `updateMetadata`, and `deleteMetadata` methods in `MetadataManagementServiceImpl` always resolved the tenant ID from the currently active Carbon context, which is carbon.super. This caused all per-tenant metadata entries to be stored under the super tenant's ID rather than the intended target tenant's ID.

## Goals
Ensure that per-tenant metadata entries (_PER_DEVICE_COST, _dfrm_enabled_tenant, _permission_config) are created, updated, and deleted under the correct target tenant's context.

## Approach
Introduced two private helper methods:

- `isPerTenantMetaKey(String metaKey)` - determines whether a given metaKey requires tenant-scoped storage by checking for the known per-tenant key suffixes.

- `extractTenantDomain(String metaKey)` - extracts the target tenant domain from a per-tenant metaKey by stripping the known suffix.

Three new private tenant-scoped operation methods were introduced:
- `createMetadataForTenant`, `updateMetadataForTenant`, and `deleteMetadataForTenant` - each uses `PrivilegedCarbonContext.startTenantFlow()` to temporarily switch the active tenant context to the resolved target tenant, performs the DAO operation under that context, and always restores the original context in the finally block via `PrivilegedCarbonContext.endTenantFlow()` to prevent context leaks.

## Related PRs
https://github.com/entgra-proprietary/emm-proprietary-plugins/pull/250

## Related Issue Ticket
https://roadmap.entgra.net/issues/16923