### PR TITLE
Add Admin APIs to Publish Scopes and Update Scope Role Bindings for Sub-Tenants

### DIFF
--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/api/admin/UserManagementAdminService.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/api/admin/UserManagementAdminService.java
@@ -75,6 +75,13 @@ import javax.ws.rs.core.Response;
                         key = "um:admin:users:view",
                         roles = {"Internal/devicemgt-admin"},
                         permissions = {"/device-mgt/admin/users/view"}
+                ),
+                @Scope(
+                        name = "Update Tenant Scope Bindings",
+                        description = "Update Tenant Scope Bindings",
+                        key = "um:admin:users:view",
+                        roles = {"Internal/devicemgt-admin"},
+                        permissions = {"/device-mgt/admin/users/view"}
                 )
         }
 )
@@ -328,7 +335,7 @@ public interface UserManagementAdminService {
             tags = "Tenant details management",
             extensions = {
                     @Extension(properties = {
-                            @ExtensionProperty(name = Constants.SCOPE, value = "um:admin:tenants:publish-scopes")
+                            @ExtensionProperty(name = Constants.SCOPE, value = "um:admin:users:view")
                     })
             }
     )
@@ -349,4 +356,51 @@ public interface UserManagementAdminService {
                     required = true)
             @PathParam("tenantDomain")
             String tenantDomain);
+
+    @PUT
+    @Path("/domain/{tenantDomain}/scopes/{roleName}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            consumes = MediaType.APPLICATION_JSON,
+            produces = MediaType.APPLICATION_JSON,
+            httpMethod = "PUT",
+            value = "Add a role to the bindings of the specified scopes in a tenant.",
+            notes = "This API allows adding a role to the bindings of a list of scopes within a tenant. " +
+                    "Provide the tenant domain, the role name, and a list of scope names whose bindings should be updated.",
+            tags = "Tenant details management",
+            extensions = {
+                    @Extension(properties = {
+                            @ExtensionProperty(name = Constants.SCOPE, value = "um:admin:users:view")
+                    })
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "OK. \n Role has been added to the specified scope bindings successfully."),
+            @ApiResponse(
+                    code = 401,
+                    message = "Unauthorized. \n Unauthorized attempt to update scope bindings."),
+            @ApiResponse(
+                    code = 500,
+                    message = "Internal Server Error. \n Server error occurred while updating scope bindings.",
+                    response = ErrorResponse.class)
+    })
+    Response updateTenantScopeBindings(
+            @ApiParam(
+                    name = "tenantDomain",
+                    value = "The domain of the tenant.",
+                    required = true)
+            @PathParam("tenantDomain")
+            String tenantDomain,
+            @ApiParam(
+                    name = "roleName",
+                    value = "The name of the role to add to the scope bindings.",
+                    required = true)
+            @PathParam("roleName")
+            String roleName,
+            @ApiParam(
+                    name = "scopeNames",
+                    value = "The list of scope names whose bindings should be updated with the given role.",
+                    required = true)
+            java.util.List<String> scopeNames);
 }

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/api/admin/UserManagementAdminService.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/api/admin/UserManagementAdminService.java
@@ -68,6 +68,13 @@ import javax.ws.rs.core.Response;
                         key = "um:admin:tenants:remove",
                         roles = {"Internal/devicemgt-admin"},
                         permissions = {"/device-mgt/admin/tenants/delete"}
+                ),
+                @Scope(
+                        name = "Publish Scopes to Tenant",
+                        description = "Publish Scopes to Tenant",
+                        key = "um:admin:users:view",
+                        roles = {"Internal/devicemgt-admin"},
+                        permissions = {"/device-mgt/admin/users/view"}
                 )
         }
 )
@@ -307,4 +314,39 @@ public interface UserManagementAdminService {
             @QueryParam("deleteAppArtifacts")
             @DefaultValue("false")
             boolean deleteAppArtifacts);
+
+    @POST
+    @Path("/domain/{tenantDomain}/scopes")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            consumes = MediaType.APPLICATION_JSON,
+            produces = MediaType.APPLICATION_JSON,
+            httpMethod = "POST",
+            value = "Publish scopes to a tenant by tenant domain.",
+            notes = "This API allows the publishing of scopes to a tenant by providing the tenant domain.",
+            tags = "Tenant details management",
+            extensions = {
+                    @Extension(properties = {
+                            @ExtensionProperty(name = Constants.SCOPE, value = "um:admin:tenants:publish-scopes")
+                    })
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "OK. \n Scopes have been published successfully."),
+            @ApiResponse(
+                    code = 401,
+                    message = "Unauthorized. \n Unauthorized attempt to publish scopes to tenant."),
+            @ApiResponse(
+                    code = 500,
+                    message = "Internal Server Error. \n Server error occurred while publishing scopes to the tenant.",
+                    response = ErrorResponse.class)
+    })
+    Response publishScopesToTenant(
+            @ApiParam(
+                    name = "tenantDomain",
+                    value = "The domain of the tenant to publish scopes to.",
+                    required = true)
+            @PathParam("tenantDomain")
+            String tenantDomain);
 }

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/api/admin/UserManagementAdminService.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/api/admin/UserManagementAdminService.java
@@ -72,16 +72,16 @@ import javax.ws.rs.core.Response;
                 @Scope(
                         name = "Publish Scopes to Tenant",
                         description = "Publish Scopes to Tenant",
-                        key = "um:admin:users:view",
+                        key = "um:admin:users:modify",
                         roles = {"Internal/devicemgt-admin"},
-                        permissions = {"/device-mgt/admin/users/view"}
+                        permissions = {"/device-mgt/admin/users/modify"}
                 ),
                 @Scope(
                         name = "Update Tenant Scope Bindings",
                         description = "Update Tenant Scope Bindings",
-                        key = "um:admin:users:view",
+                        key = "um:admin:users:modify",
                         roles = {"Internal/devicemgt-admin"},
-                        permissions = {"/device-mgt/admin/users/view"}
+                        permissions = {"/device-mgt/admin/users/modify"}
                 )
         }
 )
@@ -335,7 +335,7 @@ public interface UserManagementAdminService {
             tags = "Tenant details management",
             extensions = {
                     @Extension(properties = {
-                            @ExtensionProperty(name = Constants.SCOPE, value = "um:admin:users:view")
+                            @ExtensionProperty(name = Constants.SCOPE, value = "um:admin:users:modify")
                     })
             }
     )
@@ -371,7 +371,7 @@ public interface UserManagementAdminService {
             tags = "Tenant details management",
             extensions = {
                     @Extension(properties = {
-                            @ExtensionProperty(name = Constants.SCOPE, value = "um:admin:users:view")
+                            @ExtensionProperty(name = Constants.SCOPE, value = "um:admin:users:modify")
                     })
             }
     )

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/impl/admin/UserManagementAdminServiceImpl.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/impl/admin/UserManagementAdminServiceImpl.java
@@ -36,6 +36,7 @@ import javax.validation.constraints.Size;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -173,4 +174,33 @@ public class UserManagementAdminServiceImpl implements UserManagementAdminServic
         }
     }
 
+    @PUT
+    @Path("/domain/{tenantDomain}/scopes/{roleName}")
+    @Override
+    public Response updateTenantScopeBindings(@PathParam("tenantDomain") String tenantDomain,
+                                              @PathParam("roleName") String roleName,
+                                              java.util.List<String> scopeNames) {
+        try {
+            if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
+                String msg = "You are not allowed to update scope bindings for the super tenant.";
+                log.error(msg);
+                return Response.status(Response.Status.UNAUTHORIZED).entity(msg).build();
+            }
+
+            if (log.isDebugEnabled()) {
+                log.debug("Scope bindings update process has been initiated for tenant: " + tenantDomain
+                        + " and role: " + roleName);
+            }
+
+            TenantManagerAdminService tenantManagerAdminService = DeviceMgtAPIUtils.getTenantManagerAdminService();
+            tenantManagerAdminService.updateTenantScopeBindings(tenantDomain, roleName, scopeNames);
+
+            return Response.status(Response.Status.OK).entity("Scope bindings update process has been completed " +
+                    "successfully for tenant: " + tenantDomain).build();
+        } catch (TenantMgtException e) {
+            String msg = "Error occurred while updating scope bindings for tenant: " + tenantDomain;
+            log.error(msg, e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(msg).build();
+        }
+    }
 }

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/impl/admin/UserManagementAdminServiceImpl.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.api/src/main/java/io/entgra/device/mgt/core/device/mgt/api/jaxrs/service/impl/admin/UserManagementAdminServiceImpl.java
@@ -141,4 +141,36 @@ public class UserManagementAdminServiceImpl implements UserManagementAdminServic
         }
     }
 
+    @POST
+    @Path("/domain/{tenantDomain}/scopes")
+    @Override
+    public Response publishScopesToTenant(@PathParam("tenantDomain") String tenantDomain) {
+        try {
+            if (CarbonContext.getThreadLocalCarbonContext().getTenantId() != MultitenantConstants.SUPER_TENANT_ID){
+                String msg = "Only super tenants are allowed to publish scopes to tenants.";
+                log.error(msg);
+                return Response.status(Response.Status.UNAUTHORIZED).entity(msg).build();
+            }
+            if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
+                String msg = "You are not allowed to publish scopes to the super tenant.";
+                log.error(msg);
+                return Response.status(Response.Status.UNAUTHORIZED).entity(msg).build();
+            }
+
+            if (log.isDebugEnabled()) {
+                log.debug("Scope publishing process has been initiated for tenant:" + tenantDomain);
+            }
+
+            TenantManagerAdminService tenantManagerAdminService = DeviceMgtAPIUtils.getTenantManagerAdminService();
+            tenantManagerAdminService.publishScopesToTenant(tenantDomain);
+
+            return Response.status(Response.Status.OK).entity("Scope publishing process has been completed " +
+                    "successfully for tenant: " + tenantDomain).build();
+        } catch (TenantMgtException e) {
+            String msg = "Error occurred while publishing scopes to tenant: " + tenantDomain;
+            log.error(msg, e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(msg).build();
+        }
+    }
+
 }

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/test/resources/config/operation/mdm-ui-config.xml
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/test/resources/config/operation/mdm-ui-config.xml
@@ -301,6 +301,7 @@
         <Scope>um:users:update</Scope>
         <Scope>um:users:invite</Scope>
         <Scope>um:admin:users:view</Scope>
+        <Scope>um:admin:users:modify</Scope>
         <Scope>dm:admin:enrollment:update</Scope>
         <Scope>gm:devices:view</Scope>
         <Scope>gm:groups:update</Scope>

--- a/components/tenant-mgt/io.entgra.device.mgt.core.tenant.mgt.common/src/main/java/io/entgra/device/mgt/core/tenant/mgt/common/spi/TenantManagerAdminService.java
+++ b/components/tenant-mgt/io.entgra.device.mgt.core.tenant.mgt.common/src/main/java/io/entgra/device/mgt/core/tenant/mgt/common/spi/TenantManagerAdminService.java
@@ -25,4 +25,5 @@ public interface TenantManagerAdminService {
     void deleteTenant(String tenantDomain) throws TenantMgtException;
     int getTenantId(String tenantDomain) throws TenantMgtException;
     void publishScopesToTenant(String tenantDomain) throws TenantMgtException;
+    void updateTenantScopeBindings(String tenantDomain, String roleName, java.util.List<String> scopeNames) throws TenantMgtException;
 }

--- a/components/tenant-mgt/io.entgra.device.mgt.core.tenant.mgt.common/src/main/java/io/entgra/device/mgt/core/tenant/mgt/common/spi/TenantManagerAdminService.java
+++ b/components/tenant-mgt/io.entgra.device.mgt.core.tenant.mgt.common/src/main/java/io/entgra/device/mgt/core/tenant/mgt/common/spi/TenantManagerAdminService.java
@@ -24,4 +24,5 @@ public interface TenantManagerAdminService {
 
     void deleteTenant(String tenantDomain) throws TenantMgtException;
     int getTenantId(String tenantDomain) throws TenantMgtException;
+    void publishScopesToTenant(String tenantDomain) throws TenantMgtException;
 }

--- a/components/tenant-mgt/io.entgra.device.mgt.core.tenant.mgt.core/src/main/java/io/entgra/device/mgt/core/tenant/mgt/core/TenantManager.java
+++ b/components/tenant-mgt/io.entgra.device.mgt.core.tenant.mgt.core/src/main/java/io/entgra/device/mgt/core/tenant/mgt/core/TenantManager.java
@@ -87,4 +87,14 @@ public interface TenantManager {
      * @throws TenantMgtException If an error occurs while initializing the metadata for the tenant.
      */
     void addDefaultNotificationArchivalMetadata(TenantInfoBean tenantInfoBean) throws TenantMgtException;
+
+    /**
+     * Adds a role to the bindings of the specified scopes within a tenant.
+     *
+     * @param tenantDomain The domain of the tenant.
+     * @param roleName     The name of the role to add to each scope's bindings.
+     * @param scopeNames   The list of scope names whose bindings should be updated.
+     * @throws TenantMgtException If an error occurs while updating the scope bindings.
+     */
+    void updateTenantScopeBindings(String tenantDomain, String roleName, java.util.List<String> scopeNames) throws TenantMgtException;
 }

--- a/components/tenant-mgt/io.entgra.device.mgt.core.tenant.mgt.core/src/main/java/io/entgra/device/mgt/core/tenant/mgt/core/impl/TenantManagerAdminServiceImpl.java
+++ b/components/tenant-mgt/io.entgra.device.mgt.core.tenant.mgt.core/src/main/java/io/entgra/device/mgt/core/tenant/mgt/core/impl/TenantManagerAdminServiceImpl.java
@@ -66,4 +66,15 @@ public class TenantManagerAdminServiceImpl implements TenantManagerAdminService 
             throw new TenantMgtException(msg, e);
         }
     }
+
+    @Override
+    public void updateTenantScopeBindings(String tenantDomain, String roleName, java.util.List<String> scopeNames) throws TenantMgtException {
+        try {
+            TenantMgtDataHolder.getInstance().getTenantManager().updateTenantScopeBindings(tenantDomain, roleName, scopeNames);
+        } catch (TenantMgtException e) {
+            String msg = "Error occurred while updating scope bindings for tenant: " + tenantDomain;
+            log.error(msg, e);
+            throw new TenantMgtException(msg, e);
+        }
+    }
 }

--- a/components/tenant-mgt/io.entgra.device.mgt.core.tenant.mgt.core/src/main/java/io/entgra/device/mgt/core/tenant/mgt/core/impl/TenantManagerAdminServiceImpl.java
+++ b/components/tenant-mgt/io.entgra.device.mgt.core.tenant.mgt.core/src/main/java/io/entgra/device/mgt/core/tenant/mgt/core/impl/TenantManagerAdminServiceImpl.java
@@ -20,6 +20,7 @@ package io.entgra.device.mgt.core.tenant.mgt.core.impl;
 
 import io.entgra.device.mgt.core.tenant.mgt.common.exception.TenantMgtException;
 import io.entgra.device.mgt.core.tenant.mgt.common.spi.TenantManagerAdminService;
+import io.entgra.device.mgt.core.tenant.mgt.core.internal.TenantMgtDataHolder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.stratos.common.exception.StratosException;
@@ -50,6 +51,17 @@ public class TenantManagerAdminServiceImpl implements TenantManagerAdminService 
             return tenantMgtAdminService.getTenant(tenantDomain).getTenantId();
         } catch (Exception e){
             String msg = "Error occurred while getting tenant ID of domain: " + tenantDomain;
+            log.error(msg, e);
+            throw new TenantMgtException(msg, e);
+        }
+    }
+
+    @Override
+    public void publishScopesToTenant(String tenantDomain) throws TenantMgtException {
+        try {
+            TenantMgtDataHolder.getInstance().getTenantManager().publishScopesToTenant(tenantDomain);
+        } catch (TenantMgtException e) {
+            String msg = "Error occurred while publishing scopes to tenant: " + tenantDomain;
             log.error(msg, e);
             throw new TenantMgtException(msg, e);
         }

--- a/components/tenant-mgt/io.entgra.device.mgt.core.tenant.mgt.core/src/main/java/io/entgra/device/mgt/core/tenant/mgt/core/impl/TenantManagerImpl.java
+++ b/components/tenant-mgt/io.entgra.device.mgt.core.tenant.mgt.core/src/main/java/io/entgra/device/mgt/core/tenant/mgt/core/impl/TenantManagerImpl.java
@@ -501,4 +501,67 @@ public class TenantManagerImpl implements TenantManager {
             endTenantFlow();
         }
     }
+    @Override
+    public void updateTenantScopeBindings(String tenantDomain, String roleName, List<String> scopeNames) throws TenantMgtException {
+        if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
+            String msg = "Updating scope bindings for super tenant is not allowed via this operation.";
+            log.error(msg);
+            throw new TenantMgtException(msg);
+        }
+        try {
+            PrivilegedCarbonContext.startTenantFlow();
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
+            PublisherRESTAPIServices publisherRESTAPIServices = TenantMgtDataHolder.getInstance().getPublisherRESTAPIServices();
+
+            Scope[] subTenantScopes = publisherRESTAPIServices.getScopes();
+            if (subTenantScopes == null) {
+                return;
+            }
+
+            Map<String, Scope> scopeMap = new HashMap<>();
+            for (Scope scope : subTenantScopes) {
+                scopeMap.put(scope.getName(), scope);
+            }
+
+            for (String scopeName : scopeNames) {
+                Scope targetScope = scopeMap.get(scopeName);
+                if (targetScope == null) {
+                    log.warn("Scope '" + scopeName + "' not found in tenant '" + tenantDomain + "'. Skipping.");
+                    continue;
+                }
+                List<String> bindings = targetScope.getBindings();
+                if (bindings == null) {
+                    bindings = new ArrayList<>();
+                }
+                if (!bindings.contains(roleName)) {
+                    bindings.add(roleName);
+                    targetScope.setBindings(bindings);
+                    publisherRESTAPIServices.updateSharedScope(targetScope);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Added role '" + roleName + "' to bindings of scope '" + scopeName
+                                + "' in tenant '" + tenantDomain + "'.");
+                    }
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Role '" + roleName + "' already present in bindings of scope '" + scopeName
+                                + "' in tenant '" + tenantDomain + "'. Skipping.");
+                    }
+                }
+            }
+        } catch (BadRequestException e) {
+            String msg = "Invalid request sent when updating scope bindings for '" + tenantDomain + "' tenant space.";
+            log.error(msg, e);
+            throw new TenantMgtException(msg, e);
+        } catch (UnexpectedResponseException e) {
+            String msg = "Unexpected response received when updating scope bindings for '" + tenantDomain + "' tenant space.";
+            log.error(msg, e);
+            throw new TenantMgtException(msg, e);
+        } catch (APIServicesException e) {
+            String msg = "Error occurred while updating scope bindings for '" + tenantDomain + "' tenant space.";
+            log.error(msg, e);
+            throw new TenantMgtException(msg, e);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+    }
 }


### PR DESCRIPTION
## Purpose
There was no programmatic way for super tenant admins to publish API scopes to sub-tenants or update scope role bindings within a tenant after creation. 

## Goals
1. Introduce a REST API endpoint for super tenant admins to publish scopes to a specified sub-tenant by domain.
2.  Introduce a REST API endpoint to add a role to the bindings of one or more specified scopes within a tenant.

## Approach
Two new admin REST API endpoints have been added to `UserManagementAdminService`:

POST `/domain/{tenantDomain}/scopes` - Triggers scope publishing for the given sub-tenant. Only callable by super tenant admins. It uses the existing `publishScopesToTenant` method from the `TenantManager` class. The logic behind it is to compare the scopes between the super tenant and the specified sub tenant and publish anything that's missing from the sub tenant.

PUT `/domain/{tenantDomain}/scopes/{roleName}` - Accepts a list of scope names and adds the specified role to the bindings of each matching scope in the tenant. 

## Related Issue Ticket
https://roadmap.entgra.net/issues/16850

## Related PR
https://github.com/entgra-proprietary/product-dfrm/pull/163