### PR TITLE
Update Cdm configurations for mqtt compression

### DIFF
--- a/features/device-mgt/io.entgra.device.mgt.core.device.mgt.basics.feature/src/main/resources/conf/cdm-config.xml
+++ b/features/device-mgt/io.entgra.device.mgt.core.device.mgt.basics.feature/src/main/resources/conf/cdm-config.xml
@@ -210,7 +210,7 @@
     </OperationTimeoutConfigurations>
     <MQTTConfigurations>
         <CompressionThresholdKb>4</CompressionThresholdKb>
-        <CompressionLevel>1</CompressionLevel>
+        <CompressionLevel>0</CompressionLevel>
     </MQTTConfigurations>
     <EnrollmentGuideConfiguration>
         <Enable>false</Enable>

--- a/features/device-mgt/io.entgra.device.mgt.core.device.mgt.basics.feature/src/main/resources/conf_templates/templates/repository/conf/cdm-config.xml.j2
+++ b/features/device-mgt/io.entgra.device.mgt.core.device.mgt.basics.feature/src/main/resources/conf_templates/templates/repository/conf/cdm-config.xml.j2
@@ -392,7 +392,7 @@
         </CompressionLevel>
         {% else %}
         <CompressionThresholdKb>4</CompressionThresholdKb>
-        <CompressionLevel>1</CompressionLevel>
+        <CompressionLevel>0</CompressionLevel>
         {% endif %}
     </MQTTConfigurations>
     <EnrollmentGuideConfiguration>


### PR DESCRIPTION

## Purpose

- Change the default MQTT compression level to **0** (no compression) so that MQTT payloads are not compressed by default.
- Compression can be enabled through configuration by setting the desired compression level and threshold in `cdm-config.xml`. or project deployment.toml file

Related PR: https://github.com/entgra/device-mgt-plugins/pull/26  
Related Issue: https://roadmap.entgra.net/issues/15995

## Approach

- Updated the default MQTT compression level to **0** (`NO_COMPRESSION`).
- Updated the `cdm-config.xml.j2` template to use a default MQTT compression level of **0**.
- Preserved configurability so deployments can enable compression by specifying an appropriate compression level (e.g., `1` for best speed) and compression threshold.