### PR TITLE
Fix heartbeat candidate re-election to retain active candidate server

### DIFF
--- a/components/heartbeat-management/io.entgra.device.mgt.core.server.bootup.heartbeat.beacon/src/main/java/io/entgra/device/mgt/core/server/bootup/heartbeat/beacon/service/HeartBeatManagementServiceImpl.java
+++ b/components/heartbeat-management/io.entgra.device.mgt.core.server.bootup.heartbeat.beacon/src/main/java/io/entgra/device/mgt/core/server/bootup/heartbeat/beacon/service/HeartBeatManagementServiceImpl.java
@@ -200,7 +200,13 @@ public class HeartBeatManagementServiceImpl implements HeartBeatManagementServic
                         if (presentCandidate.getTimeOfElection().before(new Timestamp(System.currentTimeMillis()
                                 - TimeUnit.SECONDS.toMillis(elapsedTimeInSeconds)))) {
                             heartBeatDAO.purgeCandidates();
-                            electCandidate(servers);
+                            // Check if the present candidate is still an active server before re-electing
+                            String presentCandidateServerUUID = presentCandidate.getServerUUID();
+                            if (servers.containsKey(presentCandidateServerUUID)) {
+                                heartBeatDAO.recordElectedCandidate(presentCandidateServerUUID);
+                            } else {
+                                electCandidate(servers);
+                            }
                         }
                     } else {
                         //first time execution, elect if not present


### PR DESCRIPTION
## Purpose

The heartbeat node election process was switching the elected node periodically even when the current elected node was still active.

Example:
- W1 is elected as the active node.
- After the next heartbeat cycle, W2 becomes the elected node.

Due to this unnecessary re-election, scheduled tasks could be executed by multiple servers simultaneously, causing duplicate scheduler executions.

Roadmap tickets: 
https://roadmap.entgra.net/issues/17577
https://roadmap.entgra.net/issues/17469 (parent)

## Goals

- Prevent unnecessary elected node changes during the heartbeat election process.
- Maintain the current elected node as long as it remains active.
- Ensure that randomly assigned scheduled tasks are executed by only one qualified node at a time.

## Approach

- Updated the heartbeat candidate election logic to validate the currently elected node before performing a new election.
- During the election process:
  - Retrieve the currently elected node.
  - Check whether the existing elected node is available in the active server list.
  - If the current elected node is still active, retain it as the elected node.
  - Trigger a new election only when the current elected node is no longer active.
- This prevents unnecessary node switching and improves scheduler execution reliability in a clustered environment.