### PR TITLE
add customizable SSE timeout configuration

### DIFF
--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/config/DeviceManagementConfig.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/config/DeviceManagementConfig.java
@@ -41,6 +41,7 @@ import io.entgra.device.mgt.core.device.mgt.core.config.status.task.DeviceStatus
 import io.entgra.device.mgt.core.device.mgt.core.config.task.TaskConfiguration;
 import io.entgra.device.mgt.core.device.mgt.core.event.config.EventOperationTaskConfiguration;
 import io.entgra.device.mgt.core.device.mgt.core.config.permission.DefaultPermissions;
+import io.entgra.device.mgt.core.device.mgt.core.config.ui.request.UIRequestConfiguration;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -78,6 +79,7 @@ public final class DeviceManagementConfig {
     private EnrollmentGuideConfiguration enrollmentGuideConfiguration;
     private MQTTConfiguration mqttConfiguration;
     private DefaultPermissions defaultPermissions;
+    private UIRequestConfiguration uiRequestConfiguration;
 
     @XmlElement(name = "ManagementRepository", required = true)
     public DeviceManagementConfigRepository getDeviceManagementConfigRepository() {
@@ -308,6 +310,15 @@ public final class DeviceManagementConfig {
 
     public void setMqttConfiguration(MQTTConfiguration mqttConfiguration) {
         this.mqttConfiguration = mqttConfiguration;
+    }
+
+    @XmlElement(name = "UIRequestConfiguration", required = false)
+    public UIRequestConfiguration getUiRequestConfiguration() {
+        return uiRequestConfiguration;
+    }
+
+    public void setUiRequestConfiguration(UIRequestConfiguration uiRequestConfiguration) {
+        this.uiRequestConfiguration = uiRequestConfiguration;
     }
 
 }

--- a/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/config/ui/request/UIRequestConfiguration.java
+++ b/components/device-mgt/io.entgra.device.mgt.core.device.mgt.core/src/main/java/io/entgra/device/mgt/core/device/mgt/core/config/ui/request/UIRequestConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018 - 2026, Entgra (Pvt) Ltd. (http://www.entgra.io) All Rights Reserved.
+ *
+ * Entgra (Pvt) Ltd. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.entgra.device.mgt.core.device.mgt.core.config.ui.request;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Represents UI Request Configuration.
+ */
+@XmlRootElement(name = "UIRequestConfiguration")
+public class UIRequestConfiguration {
+
+    private int sseTimeout;
+
+    @XmlElement(name = "SSETimeout")
+    public int getSseTimeout() {
+        return sseTimeout;
+    }
+
+    public void setSseTimeout(int sseTimeout) {
+        this.sseTimeout = sseTimeout;
+    }
+}

--- a/components/ui-request-interceptor/io.entgra.device.mgt.core.ui.request.interceptor/src/main/java/io/entgra/device/mgt/core/ui/request/interceptor/SSEHandler.java
+++ b/components/ui-request-interceptor/io.entgra.device.mgt.core.ui.request.interceptor/src/main/java/io/entgra/device/mgt/core/ui/request/interceptor/SSEHandler.java
@@ -23,6 +23,9 @@ import io.entgra.device.mgt.core.notification.mgt.core.util.NotificationEventBro
 import io.entgra.device.mgt.core.notification.mgt.core.util.NotificationListener;
 import io.entgra.device.mgt.core.notification.mgt.core.dao.NotificationManagementDAO;
 import io.entgra.device.mgt.core.notification.mgt.core.dao.factory.NotificationManagementDAOFactory;
+import io.entgra.device.mgt.core.device.mgt.core.config.DeviceConfigurationManager;
+import io.entgra.device.mgt.core.device.mgt.core.config.DeviceManagementConfig;
+import io.entgra.device.mgt.core.device.mgt.core.config.ui.request.UIRequestConfiguration;
 import io.entgra.device.mgt.core.ui.request.interceptor.beans.AuthData;
 import io.entgra.device.mgt.core.ui.request.interceptor.util.HandlerConstants;
 import org.apache.commons.logging.Log;
@@ -32,8 +35,10 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.servlet.AsyncContext;
 import javax.servlet.AsyncEvent;
 import javax.servlet.AsyncListener;
@@ -54,6 +59,7 @@ public class SSEHandler extends HttpServlet implements NotificationListener {
     private static final Map<String, List<AsyncContext>> userStreams = new ConcurrentHashMap<>();
     private final NotificationManagementDAO notificationDAO =
             NotificationManagementDAOFactory.getNotificationManagementDAO();
+    private long sseTimeout;
 
     /**
      * initializes the servlet and registers this instance as a notification listener.
@@ -62,6 +68,18 @@ public class SSEHandler extends HttpServlet implements NotificationListener {
      */
     @Override
     public void init(ServletConfig config) {
+        try {
+            DeviceManagementConfig deviceManagementConfig = DeviceConfigurationManager.getInstance()
+                    .getDeviceManagementConfig();
+            if (deviceManagementConfig != null) {
+                UIRequestConfiguration uiRequestConfig = deviceManagementConfig.getUiRequestConfiguration();
+                if (uiRequestConfig != null) {
+                    this.sseTimeout = uiRequestConfig.getSseTimeout();
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error occurred while reading UIRequestConfiguration. Using default timeout.", e);
+        }
         // register as a notification listener
         NotificationEventBroker.registerListener(this);
     }
@@ -143,23 +161,39 @@ public class SSEHandler extends HttpServlet implements NotificationListener {
         res.setContentType("text/event-stream");
         res.setCharacterEncoding("UTF-8");
         final AsyncContext ac = req.startAsync();
-        ac.setTimeout(0);
+        ac.setTimeout(sseTimeout);
         userStreams.computeIfAbsent(notificationUsername, k -> new CopyOnWriteArrayList<>()).add(ac);
         if (!notificationUsername.equals(sessionUsername)) {
             userStreams.computeIfAbsent(sessionUsername, k -> new CopyOnWriteArrayList<>()).add(ac);
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Opened SSE connection for user: " + sessionUsername + ". Active connections: "
+                    + getActiveConnectionCount());
         }
         ac.addListener(new AsyncListener() {
             @Override
             public void onComplete(AsyncEvent event) {
                 removeContext(ac);
+                if (log.isDebugEnabled()) {
+                    log.debug("Completed SSE connection for user: " + sessionUsername + ". Active connections: "
+                            + getActiveConnectionCount());
+                }
             }
             @Override
             public void onTimeout(AsyncEvent event) {
                 removeContext(ac);
+                if (log.isDebugEnabled()) {
+                    log.debug("SSE connection timed out for user: " + sessionUsername + ". Active connections: "
+                            + getActiveConnectionCount());
+                }
             }
             @Override
             public void onError(AsyncEvent event) {
                 removeContext(ac);
+                if (log.isDebugEnabled()) {
+                    log.debug("SSE connection errored for user: " + sessionUsername + ". Active connections: "
+                            + getActiveConnectionCount());
+                }
             }
             @Override
             public void onStartAsync(AsyncEvent event) {
@@ -229,12 +263,30 @@ public class SSEHandler extends HttpServlet implements NotificationListener {
     }
 
     /**
+     * Returns the number of unique active SSE connections. A connection can be associated with
+     * multiple username keys, so counting the stream lists directly would over-count it.
+     *
+     * @return number of active SSE connections
+     */
+    private int getActiveConnectionCount() {
+        Set<AsyncContext> activeContexts = new HashSet<>();
+        for (List<AsyncContext> contexts : userStreams.values()) {
+            activeContexts.addAll(contexts);
+        }
+        return activeContexts.size();
+    }
+
+    /**
      * closes an SSE connection safely and removes it from tracking.
      * prevents resource leaks (open sockets/threads) when the client disconnects or an error occurs.
      * @param username the authenticated username associated with this stream
      * @param ac the async context to complete
      */
     private void closeStream(String username, AsyncContext ac) {
+        if (log.isDebugEnabled()) {
+            log.debug("Closing SSE connection for user: " + username + ". Active connections: "
+                    + getActiveConnectionCount());
+        }
         removeContext(username, ac);
         removeContext(ac);
         try {

--- a/features/device-mgt/io.entgra.device.mgt.core.device.mgt.basics.feature/src/main/resources/conf/cdm-config.xml
+++ b/features/device-mgt/io.entgra.device.mgt.core.device.mgt.basics.feature/src/main/resources/conf/cdm-config.xml
@@ -40,6 +40,9 @@
     <PullNotificationConfiguration>
         <Enabled>false</Enabled>
     </PullNotificationConfiguration>
+    <UIRequestConfiguration>
+        <SSETimeout>0</SSETimeout>
+    </UIRequestConfiguration>
     <IdentityConfiguration>
         <ServerUrl>https://localhost:9443</ServerUrl>
         <AdminUsername>${admin.username}</AdminUsername>

--- a/features/device-mgt/io.entgra.device.mgt.core.device.mgt.basics.feature/src/main/resources/conf_templates/templates/repository/conf/cdm-config.xml.j2
+++ b/features/device-mgt/io.entgra.device.mgt.core.device.mgt.basics.feature/src/main/resources/conf_templates/templates/repository/conf/cdm-config.xml.j2
@@ -61,6 +61,13 @@
         <Enabled>false</Enabled>
         {% endif %}
     </PullNotificationConfiguration>
+    <UIRequestConfiguration>
+        {% if device_mgt_conf.ui_request_conf is defined %}
+        <SSETimeout>{{device_mgt_conf.ui_request_conf.sse_timeout}}</SSETimeout>
+        {% else %}
+        <SSETimeout>0</SSETimeout>
+        {% endif %}
+    </UIRequestConfiguration>
     <IdentityConfiguration>
         {% if device_mgt_conf.identity_conf is defined %}
         <ServerUrl>{{device_mgt_conf.identity_conf.server_url}}</ServerUrl>


### PR DESCRIPTION
## Purpose
The current SSE (Server-Sent Events) connection timeout in SSEHandler.java is hardcoded to 0 (infinite). When Nginx terminates idle connections, the Tomcat connection is still maintained for SSE in the background, while new connections continue to be created. This behavior leads to a steady increase in Tomcat connection counts, eventually causing resource exhaustion and crashing the server.

## Goals
- Prevent Tomcat connection leakage caused by infinite SSE timeouts.
- Make the SSE connection timeout configurable via cdm-config.xml rather than using a hardcoded value.
- Improve visibility into SSE connection lifecycle events (open, complete, timeout, error) by logging them at the INFO level, allowing administrators to monitor active connection counts.

## Related PRs
https://github.com/entgra-support/support-carbon-device-mgt/pull/69