### PR TITLE
Add an API endpoint to synchronize scope-role mappings

### DIFF
--- a/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.keymgt.extension.api/pom.xml
+++ b/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.keymgt.extension.api/pom.xml
@@ -65,6 +65,11 @@
             <version>${io.entgra.device.mgt.core.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.entgra.device.mgt.core</groupId>
+            <artifactId>io.entgra.device.mgt.core.apimgt.webapp.publisher</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.keymgt.extension.api/src/main/java/io/entgra/device/mgt/core/apimgt/keymgt/extension/api/KeyManagerService.java
+++ b/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.keymgt.extension.api/src/main/java/io/entgra/device/mgt/core/apimgt/keymgt/extension/api/KeyManagerService.java
@@ -43,4 +43,9 @@ public interface KeyManagerService {
                                  @FormParam("username") String username,
                                  @FormParam("password") String password,
                                  @FormParam("validityPeriod") int validityPeriod);
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/scopes/sync")
+    Response syncScopes();
 }

--- a/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.keymgt.extension.api/src/main/java/io/entgra/device/mgt/core/apimgt/keymgt/extension/api/KeyManagerServiceImpl.java
+++ b/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.keymgt.extension.api/src/main/java/io/entgra/device/mgt/core/apimgt/keymgt/extension/api/KeyManagerServiceImpl.java
@@ -26,6 +26,8 @@ import io.entgra.device.mgt.core.apimgt.keymgt.extension.exception.BadRequestExc
 import io.entgra.device.mgt.core.apimgt.keymgt.extension.exception.KeyMgtException;
 import io.entgra.device.mgt.core.apimgt.keymgt.extension.service.KeyMgtService;
 import io.entgra.device.mgt.core.apimgt.keymgt.extension.service.KeyMgtServiceImpl;
+import io.entgra.device.mgt.core.apimgt.webapp.publisher.APIPublisherService;
+import io.entgra.device.mgt.core.apimgt.webapp.publisher.exception.APIManagerPublisherException;
 import io.entgra.device.mgt.core.device.mgt.common.exceptions.UnAuthorizedException;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 
@@ -87,6 +89,25 @@ public class KeyManagerServiceImpl implements KeyManagerService {
             return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
         } catch (UnAuthorizedException e) {
             return Response.status(Response.Status.UNAUTHORIZED).entity(e.getMessage()).build();
+        }
+    }
+
+    @Override
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/scopes/sync")
+    public Response syncScopes() {
+        try {
+            APIPublisherService apiPublisherService = (APIPublisherService) PrivilegedCarbonContext
+                    .getThreadLocalCarbonContext().getOSGiService(APIPublisherService.class, null);
+            if (apiPublisherService == null) {
+                throw new IllegalStateException("API publisher service is unavailable");
+            }
+            apiPublisherService.updateScopeRoleMapping();
+            String msg = "Scope role mappings synchronized successfully";
+            return Response.status(Response.Status.OK).entity(msg).build();
+        } catch (APIManagerPublisherException | IllegalStateException e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(e.getMessage()).build();
         }
     }
 }

--- a/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.keymgt.extension.api/src/main/java/io/entgra/device/mgt/core/apimgt/keymgt/extension/api/KeyManagerServiceImpl.java
+++ b/components/apimgt-extensions/io.entgra.device.mgt.core.apimgt.keymgt.extension.api/src/main/java/io/entgra/device/mgt/core/apimgt/keymgt/extension/api/KeyManagerServiceImpl.java
@@ -29,6 +29,8 @@ import io.entgra.device.mgt.core.apimgt.keymgt.extension.service.KeyMgtServiceIm
 import io.entgra.device.mgt.core.apimgt.webapp.publisher.APIPublisherService;
 import io.entgra.device.mgt.core.apimgt.webapp.publisher.exception.APIManagerPublisherException;
 import io.entgra.device.mgt.core.device.mgt.common.exceptions.UnAuthorizedException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 
 import javax.ws.rs.*;
@@ -38,6 +40,7 @@ import java.util.Base64;
 
 public class KeyManagerServiceImpl implements KeyManagerService {
 
+    private static final Log log = LogFactory.getLog(KeyManagerServiceImpl.class);
     Gson gson = new Gson();
 
     @Override
@@ -101,13 +104,17 @@ public class KeyManagerServiceImpl implements KeyManagerService {
             APIPublisherService apiPublisherService = (APIPublisherService) PrivilegedCarbonContext
                     .getThreadLocalCarbonContext().getOSGiService(APIPublisherService.class, null);
             if (apiPublisherService == null) {
-                throw new IllegalStateException("API publisher service is unavailable");
+                String msg = "API publisher service is unavailable";
+                log.error(msg);
+                throw new IllegalStateException(msg);
             }
             apiPublisherService.updateScopeRoleMapping();
             String msg = "Scope role mappings synchronized successfully";
             return Response.status(Response.Status.OK).entity(msg).build();
         } catch (APIManagerPublisherException | IllegalStateException e) {
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(e.getMessage()).build();
+            String msg = "Error occurred while synchronizing scope role mappings";
+            log.error(msg, e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(msg).build();
         }
     }
 }


### PR DESCRIPTION

**Purpose**  

Scope-role mappings can become outdated after role or permission changes. Currently, synchronization is performed internally during server startup, and there is no API endpoint to trigger it when required. This can leave API authorization scopes inconsistent with the latest role configurations until the server restarts.

**Goals**  

- Provide a `POST /scopes/sync` endpoint through the Key Management API.
- Trigger scope-role mapping synchronization without requiring a server restart.
- Return appropriate success and error responses based on the synchronization result.

**Related PRs**  
https://github.com/entgra-support/support-carbon-device-mgt/pull/70